### PR TITLE
Add use case code to update the values in the totals view

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -11,17 +11,18 @@
     <!-- Add any global styles for body, document, etc. -->
     <style>
       body {
-        font-family: var(--theme-font-family, 'Segoe UI',Arial, sans-serif);
+        font-family: var(--theme-font-family, 'Segoe UI', Arial, sans-serif);
       }
     </style>
-    <script>window.process = {env: {NODE_ENV: 'development'} };</script>
+    <script>
+      window.process = {env: {NODE_ENV: 'development'}};
+    </script>
   </head>
   <body class="text-body-1">
-    <noscript>
-      Please enable JavaScript to view this website.
-    </noscript>
+    <noscript> Please enable JavaScript to view this website. </noscript>
     <h1>ISNCSCI Algorithm App</h1>
     <praxis-isncsci-input-layout></praxis-isncsci-input-layout>
+    <praxis-isncsci-totals></praxis-isncsci-totals>
     <script src="scripts/bundle.js" type="module"></script>
   </body>
 </html>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,11 +1,18 @@
-import {IAppState, IIsncsciAppStoreProvider, StatusCodes} from '@core/boundaries';
+import {
+  IAppState,
+  IIsncsciAppStoreProvider,
+  StatusCodes,
+} from '@core/boundaries';
 import {
   initializeAppUseCase,
-  loadExternalExamDataUseCase
+  loadExternalExamDataUseCase,
 } from '@core/useCases';
 
 import {IDataStore} from '@app/store';
-import {ExternalMessagePortProvider, ExternalMessagePortProviderActions} from '@app/providers';
+import {
+  ExternalMessagePortProvider,
+  ExternalMessagePortProviderActions,
+} from '@app/providers';
 import {InputLayoutController} from '@app/controllers/inputLayout.controller';
 
 export class App {
@@ -14,10 +21,19 @@ export class App {
   private unsubscribeFromExternalChannelHandler: Function | null = null;
   private ready = false;
 
-  public constructor(private appStore: IDataStore<IAppState>, private appStoreProvider: IIsncsciAppStoreProvider) {
-    this.unsubscribeFromStoreHandler = appStore.subscribe((state: IAppState, actionType: string) => this.stateChanged(state, actionType));
+  public constructor(
+    private appStore: IDataStore<IAppState>,
+    private appStoreProvider: IIsncsciAppStoreProvider,
+  ) {
+    this.unsubscribeFromStoreHandler = appStore.subscribe(
+      (state: IAppState, actionType: string) =>
+        this.stateChanged(state, actionType),
+    );
     this.unsubscribeFromExternalChannelHandler =
-      this.externalMessagePortProvider.subscribe((action: string, examData: {[key: string]: string} | null) => this.externalMessagePortProvider_onAction(action, examData));
+      this.externalMessagePortProvider.subscribe(
+        (action: string, examData: {[key: string]: string} | null) =>
+          this.externalMessagePortProvider_onAction(action, examData),
+      );
 
     window.addEventListener('load', () => this.window_onLoad());
   }
@@ -32,24 +48,33 @@ export class App {
     }
   }
 
-  public loadExam() {
-    console.log('loadExam');
-  }
-
   private window_onLoad() {
     const inputLayout = document.querySelector('praxis-isncsci-input-layout');
-    
-    if (!inputLayout || !inputLayout.shadowRoot) {
-      throw new Error('The input layout has not been initialized');
+    const totalsView = document.querySelector('praxis-isncsci-totals');
+
+    if (
+      !inputLayout ||
+      !inputLayout.shadowRoot ||
+      !totalsView ||
+      !totalsView.shadowRoot
+    ) {
+      throw new Error('The views have not been initialized');
     }
 
-    new InputLayoutController(this.appStore, inputLayout as HTMLElement);
+    new InputLayoutController(
+      this.appStore,
+      inputLayout as HTMLElement,
+      totalsView as HTMLElement,
+    );
 
     initializeAppUseCase(this.appStoreProvider);
-  };
+  }
 
-  private externalMessagePortProvider_onAction(actionType: string, examData: {[key: string]: string} | null) {
-    switch(actionType) {
+  private externalMessagePortProvider_onAction(
+    actionType: string,
+    examData: {[key: string]: string} | null,
+  ) {
+    switch (actionType) {
       case ExternalMessagePortProviderActions.ON_EXTERNAL_PORT:
         console.log('An external message port has been registered');
         break;

--- a/src/app/controllers/inputLayout.controller.ts
+++ b/src/app/controllers/inputLayout.controller.ts
@@ -1,38 +1,55 @@
 import {Actions, IDataStore} from '@app/store';
 import {IAppState} from '@core/boundaries';
-import {Cell} from '@core/domain';
+import {Cell, Totals} from '@core/domain';
 
 export class InputLayoutController {
   private cells: HTMLElement[] = [];
 
-  public constructor(appStore: IDataStore<IAppState>, inputLayout: HTMLElement) {
+  public constructor(
+    appStore: IDataStore<IAppState>,
+    inputLayout: HTMLElement,
+    private totalsView: HTMLElement,
+  ) {
     if (!inputLayout.shadowRoot) {
       throw new Error('The input layout has not been initialized');
     }
 
-    inputLayout.shadowRoot.querySelectorAll('praxis-isncsci-grid')
+    if (!totalsView.shadowRoot) {
+      throw new Error('The totals have not been initialized');
+    }
+
+    inputLayout.shadowRoot
+      .querySelectorAll('praxis-isncsci-grid')
       .forEach((grid) => {
         if (!grid.shadowRoot) {
           throw new Error('The grid has not been initialized');
         }
 
         const prefix = grid.hasAttribute('left') ? 'left' : 'right';
-        const gridCells = grid.shadowRoot.querySelectorAll('praxis-isncsci-cell');
-        gridCells.forEach((cell) => this.cells[`${prefix}-${cell.getAttribute('data-observation')}`] = cell);
+        const gridCells = grid.shadowRoot.querySelectorAll(
+          'praxis-isncsci-cell',
+        );
+        gridCells.forEach(
+          (cell) =>
+            (this.cells[`${prefix}-${cell.getAttribute('data-observation')}`] =
+              cell),
+        );
       });
 
-    appStore.subscribe((state: IAppState, actionType: string) => this.stateChanged(state, actionType));
+    appStore.subscribe((state: IAppState, actionType: string) =>
+      this.stateChanged(state, actionType),
+    );
   }
 
-  private updateView(gridModel: Array<Cell | null>[]): void {
+  private updateView(gridModel: Array<Cell | null>[]) {
     gridModel.forEach((row) => {
       row.forEach((cell) => {
         if (!cell) {
           return;
         }
-        
+
         const cellElement = this.cells[`${cell?.name}`];
-        
+
         if (cellElement) {
           cellElement.innerHTML = cell?.value ?? '';
         }
@@ -40,9 +57,22 @@ export class InputLayoutController {
     });
   }
 
-  private stateChanged(state: IAppState, actionType: string): void {
+  private updateTotals(totals: Totals) {
+    Object.keys(totals).forEach((key) => {
+      const kebabCaseKey = key
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .toLowerCase();
+      this.totalsView.setAttribute(kebabCaseKey, totals[key]);
+    });
+  }
+
+  private stateChanged(state: IAppState, actionType: string) {
     if (actionType === Actions.SET_GRID_MODEL) {
       this.updateView(state.gridModel);
+    }
+
+    if (actionType === Actions.SET_TOTALS) {
+      this.updateTotals(state.totals);
     }
   }
 }

--- a/src/app/providers/appStore.provider.ts
+++ b/src/app/providers/appStore.provider.ts
@@ -1,7 +1,6 @@
-import {Exam} from 'isncsci';
-
 import {Actions, IDataStore} from '@app/store';
 import {IAppState, IIsncsciAppStoreProvider} from '@core/boundaries';
+import {Totals} from '@core/domain';
 
 export class AppStoreProvider implements IIsncsciAppStoreProvider {
   public constructor(private appStore: IDataStore<IAppState>) {}
@@ -12,6 +11,11 @@ export class AppStoreProvider implements IIsncsciAppStoreProvider {
 
   public setGridModel(gridModel: Array<any>): Promise<void> {
     this.appStore.dispatch({type: Actions.SET_GRID_MODEL, payload: gridModel});
+    return Promise.resolve();
+  }
+
+  public setTotals(totals: Totals): Promise<void> {
+    this.appStore.dispatch({type: Actions.SET_TOTALS, payload: totals});
     return Promise.resolve();
   }
 

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
@@ -1,10 +1,6 @@
 import {html} from 'lit';
 import type {Meta, StoryObj} from '@storybook/web-components';
-import {
-  MotorLevel,
-  MotorLevels as ML,
-  SensoryLevels as SL,
-} from '@core/domain';
+import {MotorLevel, MotorLevels as ML, SensoryLevels as SL} from '@core/domain';
 
 const SensoryLevels = SL.splice(0);
 const MotorLevels = ML.splice(0);
@@ -16,14 +12,41 @@ const getRandomExamData = () => {
 
   const randomElement = <T>(array: T[]): T => {
     return array[Math.floor(Math.random() * array.length)];
-  }
-
-  const examData = {
-    'deepAnalPressure': randomElement(binaryObservation),
-    'voluntaryAnalContraction': randomElement(binaryObservation),
   };
 
-  SensoryLevels.forEach(level => {
+  const examData = {
+    deepAnalPressure: randomElement(binaryObservation),
+    voluntaryAnalContraction: randomElement(binaryObservation),
+    asiaImpairmentScale: Math.floor(Math.random() * 56).toString(),
+    injuryComplete: Math.floor(Math.random() * 56).toString(),
+    leftLightTouchTotal: Math.floor(Math.random() * 56).toString(),
+    leftLowerMotorTotal: Math.floor(Math.random() * 56).toString(),
+    leftMotor: Math.floor(Math.random() * 56).toString(),
+    leftMotorTotal: Math.floor(Math.random() * 56).toString(),
+    leftMotorZpp: Math.floor(Math.random() * 56).toString(),
+    leftPinPrickTotal: Math.floor(Math.random() * 56).toString(),
+    leftSensory: Math.floor(Math.random() * 56).toString(),
+    leftSensoryZpp: Math.floor(Math.random() * 56).toString(),
+    leftTouchTotal: Math.floor(Math.random() * 56).toString(),
+    leftUpperMotorTotal: Math.floor(Math.random() * 56).toString(),
+    lowerMotorTotal: Math.floor(Math.random() * 56).toString(),
+    neurologicalLevelOfInjury: Math.floor(Math.random() * 56).toString(),
+    pinPrickTotal: Math.floor(Math.random() * 56).toString(),
+    rightLightTouchTotal: Math.floor(Math.random() * 56).toString(),
+    rightLowerMotorTotal: Math.floor(Math.random() * 56).toString(),
+    rightMotor: Math.floor(Math.random() * 56).toString(),
+    rightMotorTotal: Math.floor(Math.random() * 56).toString(),
+    rightMotorZpp: Math.floor(Math.random() * 56).toString(),
+    rightPinPrickTotal: Math.floor(Math.random() * 56).toString(),
+    rightSensory: Math.floor(Math.random() * 56).toString(),
+    rightSensoryZpp: Math.floor(Math.random() * 56).toString(),
+    rightTouchTotal: Math.floor(Math.random() * 56).toString(),
+    rightUpperMotorTotal: Math.floor(Math.random() * 56).toString(),
+    touchTotal: Math.floor(Math.random() * 56).toString(),
+    upperMotorTotal: Math.floor(Math.random() * 56).toString(),
+  };
+
+  SensoryLevels.forEach((level) => {
     examData[`rightLightTouch${level}`] = randomElement(sensoryValues);
     examData[`rightPinPrick${level}`] = randomElement(sensoryValues);
     examData[`leftLightTouch${level}`] = randomElement(sensoryValues);
@@ -44,19 +67,19 @@ const getRandomExamData = () => {
  * It needs to be written as plain JavaScript, not TypeScript.
  * I was not able to do this using a Storybook decorator, as it would try to execute the decorator before the template was loaded.
  */
-const storyInitializer  = () => {
+const storyInitializer = () => {
   let iframe = document.querySelector('iframe[isncsci]');
 
   if (!iframe) {
     return;
   }
 
-  iframe.addEventListener("load", () => {
+  iframe.addEventListener('load', () => {
     const isncsciIframe = document.querySelector('iframe');
     const button = document.querySelector('[test-button]');
     const channel = new MessageChannel();
     const port1 = channel.port1;
-  
+
     // Listen for messages on port1
     port1.onmessage = (e) => {
       console.log('Message received from iframe', e.data);
@@ -64,41 +87,48 @@ const storyInitializer  = () => {
 
     // Transfer port2 to the iframe
     if (isncsciIframe && isncsciIframe.contentWindow) {
-      isncsciIframe.contentWindow.postMessage({action: 'INITIALIZE_PORT'}, '*', [channel.port2]);
+      isncsciIframe.contentWindow.postMessage(
+        {action: 'INITIALIZE_PORT'},
+        '*',
+        [channel.port2],
+      );
     }
 
-    button?.addEventListener(
-      'click',
-      () => {
-        console.log('Message sent to iframe');
-        port1.postMessage({action: 'SET_EXAM_DATA', examData: getRandomExamData()});
-      }
-    );
+    button?.addEventListener('click', () => {
+      console.log('Message sent to iframe');
+      port1.postMessage({
+        action: 'SET_EXAM_DATA',
+        examData: getRandomExamData(),
+      });
+    });
   });
 };
 
 const template = () => html`
-    <style>
+  <style>
     iframe {
       border: none;
       height: 100%;
       min-height: 600px;
       width: 100%;
     }
-    </style>
-    <iframe isncsci src="https://ashy-river-029cc4703.3.azurestaticapps.net/"></iframe>
-    <button test-button>Load random exam</button>
-    <script>
-      // We register this way to avoid getting exceptions of functions being already declared when navigating between stories.
-      (() => {
-        const SensoryLevels =  ${JSON.stringify(SensoryLevels)};
-        const MotorLevels =  ${JSON.stringify(MotorLevels)};
-        const getRandomExamData = ${getRandomExamData.toString()};
-        const storyInitializer = ${storyInitializer.toString()};
-        storyInitializer();
-      })();
-    </script>
-  `;
+  </style>
+  <iframe
+    isncsci
+    src="https://ashy-river-029cc4703.3.azurestaticapps.net/"
+  ></iframe>
+  <button test-button>Load random exam</button>
+  <script>
+    // We register this way to avoid getting exceptions of functions being already declared when navigating between stories.
+    (() => {
+      const SensoryLevels = ${JSON.stringify(SensoryLevels)};
+      const MotorLevels = ${JSON.stringify(MotorLevels)};
+      const getRandomExamData = ${getRandomExamData.toString()};
+      const storyInitializer = ${storyInitializer.toString()};
+      storyInitializer();
+    })();
+  </script>
+`;
 
 const meta = {
   title: 'App/ExternalMessagePortProvider',

--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -7,6 +7,35 @@ class AppStore implements IDataStore<IAppState> {
   private state: IAppState = {
     gridModel: [],
     status: StatusCodes.NotInitialized,
+    totals: {
+      asiaImpairmentScale: '',
+      injuryComplete: '',
+      leftLightTouchTotal: '',
+      leftLowerMotorTotal: '',
+      leftMotor: '',
+      leftMotorTotal: '',
+      leftMotorZpp: '',
+      leftPinPrickTotal: '',
+      leftSensory: '',
+      leftSensoryZpp: '',
+      leftTouchTotal: '',
+      leftUpperMotorTotal: '',
+      lowerMotorTotal: '',
+      neurologicalLevelOfInjury: '',
+      pinPrickTotal: '',
+      rightLightTouchTotal: '',
+      rightLowerMotorTotal: '',
+      rightMotor: '',
+      rightMotorTotal: '',
+      rightMotorZpp: '',
+      rightPinPrickTotal: '',
+      rightSensory: '',
+      rightSensoryZpp: '',
+      rightTouchTotal: '',
+      rightUpperMotorTotal: '',
+      touchTotal: '',
+      upperMotorTotal: '',
+    },
   };
 
   public subscribe(handler: Function) {
@@ -17,8 +46,12 @@ class AppStore implements IDataStore<IAppState> {
       // The code after, however, will stop once it finds the handler to be removed from the subscriber's list.
       // this.handlers = this.handlers.filter((value: Function) => value != handler);
 
-      const index: number = this.handlers.findIndex((value: Function) => value === handler);
-      if (index > -1) { this.handlers.splice(index, 1); }
+      const index: number = this.handlers.findIndex(
+        (value: Function) => value === handler,
+      );
+      if (index > -1) {
+        this.handlers.splice(index, 1);
+      }
     };
   }
 
@@ -31,7 +64,9 @@ class AppStore implements IDataStore<IAppState> {
       this.state = reducer(this.state, action);
     });
 
-    this.handlers.forEach((handler: Function) => handler(this.state, action.type));
+    this.handlers.forEach((handler: Function) =>
+      handler(this.state, action.type),
+    );
   }
 }
 

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,61 +1,50 @@
 import {IAppState} from '@core/boundaries';
-import {Exam} from 'isncsci';
+import {Totals} from '@core/domain';
+
 import {IActionWithPayload} from './';
 
 export class Actions {
-  public static SET_CURRENT_EXAM = 'SET_CURRENT_EXAM';
   public static UPDATE_STATUS = 'UPDATE_STATUS';
   public static SET_GRID_MODEL = 'SET_GRID_MODEL';
+  public static SET_TOTALS = 'SET_TOTALS';
 }
 
-const currentExam = (state: IAppState, action: IActionWithPayload<{exam: Exam}>): IAppState => {
-  if (action.type !== Actions.SET_CURRENT_EXAM) {
-      return state;
-  }
-
-  return Object.assign(
-    {},
-    state,
-    {
-      currentExam: action.payload.exam,
-    }
-  );
-};
-
-const gridModel = (state: IAppState, action: IActionWithPayload<Array<any>>): IAppState => {
-  switch(action.type) {
+const gridModel = (
+  state: IAppState,
+  action: IActionWithPayload<Array<any>>,
+): IAppState => {
+  switch (action.type) {
     case Actions.SET_GRID_MODEL:
-      return Object.assign(
-        {},
-        state,
-        {gridModel: action.payload}
-      );
+      return Object.assign({}, state, {gridModel: action.payload});
     default:
       return state;
   }
 };
 
-const status = (state: IAppState, action: IActionWithPayload<number>): IAppState => {
-  switch(action.type) {
+const status = (
+  state: IAppState,
+  action: IActionWithPayload<number>,
+): IAppState => {
+  switch (action.type) {
     case Actions.UPDATE_STATUS:
-      return Object.assign(
-        {},
-        state,
-        {status: action.payload}
-      );
+      return Object.assign({}, state, {status: action.payload});
     default:
       return state;
   }
 };
 
-export {
-  currentExam,
-  gridModel,
-  status,
+const totals = (
+  state: IAppState,
+  action: IActionWithPayload<Totals>,
+): IAppState => {
+  switch (action.type) {
+    case Actions.SET_TOTALS:
+      return Object.assign({}, state, {totals: action.payload});
+    default:
+      return state;
+  }
 };
 
-export default [
-  currentExam,
-  gridModel,
-  status,
-];
+export {gridModel, status, totals};
+
+export default [gridModel, status, totals];

--- a/src/core/boundaries/iAppState.ts
+++ b/src/core/boundaries/iAppState.ts
@@ -1,6 +1,4 @@
-import {Exam} from 'isncsci';
-
-import {Cell} from '@core/domain'
+import {Cell, Totals} from '@core/domain';
 
 export class StatusCodes {
   public static Initializing: number = 2;
@@ -11,4 +9,5 @@ export class StatusCodes {
 export interface IAppState {
   gridModel: Array<Cell | null>[];
   status: number;
+  totals: Totals;
 }

--- a/src/core/boundaries/iIsncsciAppStore.provider.ts
+++ b/src/core/boundaries/iIsncsciAppStore.provider.ts
@@ -1,11 +1,10 @@
-import {Exam} from 'isncsci';
-
-import {Cell} from '@core/domain';
+import {Cell, Totals} from '@core/domain';
 
 export interface IIsncsciAppStoreProvider {
-  setGridModel(gridModel: Array<Cell | null>[]): Promise<void>;
-  // clearDermatomeSelection(): Promise<void>;
   selectDermatome(dermatomeName: string): Promise<void>;
+  setGridModel(gridModel: Array<Cell | null>[]): Promise<void>;
+  setTotals(totals: Totals): Promise<void>;
+  // clearDermatomeSelection(): Promise<void>;
   // setDermatomeValue(dermatomeName: string, value: string): Promise<void>;
   // setTotals(totals: IsncsciTotals): Promise<void>;
   // updateDermatomesInRange(dermatomeNames: string[], value: string): Promise<void>;

--- a/src/core/domain/index.ts
+++ b/src/core/domain/index.ts
@@ -9,3 +9,4 @@ export {
   ValidMotorValues,
   ValidSensoryValues,
 } from './isncsciLevels';
+export {Totals} from './totals';

--- a/src/core/domain/totals.ts
+++ b/src/core/domain/totals.ts
@@ -1,0 +1,29 @@
+export interface Totals {
+  asiaImpairmentScale: string;
+  injuryComplete: string;
+  leftLightTouchTotal: string;
+  leftLowerMotorTotal: string;
+  leftMotor: string;
+  leftMotorTotal: string;
+  leftMotorZpp: string;
+  leftPinPrickTotal: string;
+  leftSensory: string;
+  leftSensoryZpp: string;
+  leftTouchTotal: string;
+  leftUpperMotorTotal: string;
+  lowerMotorTotal: string;
+  neurologicalLevelOfInjury: string;
+  pinPrickTotal: string;
+  rightLightTouchTotal: string;
+  rightLowerMotorTotal: string;
+  rightMotor: string;
+  rightMotorTotal: string;
+  rightMotorZpp: string;
+  rightPinPrickTotal: string;
+  rightSensory: string;
+  rightSensoryZpp: string;
+  rightTouchTotal: string;
+  rightUpperMotorTotal: string;
+  touchTotal: string;
+  upperMotorTotal: string;
+}

--- a/src/core/helpers/examData.helper.spec.ts
+++ b/src/core/helpers/examData.helper.spec.ts
@@ -1,15 +1,43 @@
-import {describe, expect, it, test} from '@jest/globals';
+import {describe, expect, it} from '@jest/globals';
 import {MotorLevel, MotorLevels, SensoryLevels} from '@core/domain';
 
-import {validateExamData} from './examData.helper';
+import {bindExamDataToTotals, validateExamData} from './examData.helper';
 
 const getExamDataForAsiaE = () => {
   const examData = {
     deepAnalPressure: 'Yes',
     voluntaryAnalContraction: 'Yes',
+    // Totals
+    asiaImpairmentScale: '1',
+    injuryComplete: '2',
+    leftLightTouchTotal: '3',
+    leftLowerMotorTotal: '4',
+    leftMotor: '5',
+    leftMotorTotal: '6',
+    leftMotorZpp: '7',
+    leftPinPrickTotal: '8',
+    leftSensory: '9',
+    leftSensoryZpp: '10',
+    leftTouchTotal: '11',
+    leftUpperMotorTotal: '12',
+    lowerMotorTotal: '13',
+    neurologicalLevelOfInjury: '14',
+    pinPrickTotal: '15',
+    rightLightTouchTotal: '16',
+    rightLowerMotorTotal: '17',
+    rightMotor: '18',
+    rightMotorTotal: '19',
+    rightMotorZpp: '20',
+    rightPinPrickTotal: '21',
+    rightSensory: '22',
+    rightSensoryZpp: '23',
+    rightTouchTotal: '24',
+    rightUpperMotorTotal: '25',
+    touchTotal: '26',
+    upperMotorTotal: '27',
   };
 
-  SensoryLevels.forEach(level => {
+  SensoryLevels.forEach((level) => {
     examData[`rightLightTouch${level}`] = '2';
     examData[`rightPinPrick${level}`] = '2';
     examData[`leftLightTouch${level}`] = '2';
@@ -38,7 +66,8 @@ describe('ExamDataHelper', () => {
       const examData = getExamDataForAsiaE();
       examData['rightLightTouchC5'] = '1*';
       examData['rightLightTouchC5ReasonImpairmentNotDueToSci'] = 'Other';
-      examData['rightLightTouchC5ReasonImpairmentNotDueToSciSpecify'] = 'Something else';
+      examData['rightLightTouchC5ReasonImpairmentNotDueToSciSpecify'] =
+        'Something else';
 
       const errors = validateExamData(examData);
 
@@ -88,26 +117,107 @@ describe('ExamDataHelper', () => {
     it('should return an error if a right sensory level has a reason for impairment not due to SCI, but the level was not marked with a star', () => {
       const examData = getExamDataForAsiaE();
       examData['rightLightTouchC5ReasonImpairmentNotDueToSci'] = 'Other';
-      examData['rightLightTouchC5ReasonImpairmentNotDueToSciSpecify'] = 'Something else';
+      examData['rightLightTouchC5ReasonImpairmentNotDueToSciSpecify'] =
+        'Something else';
 
       const errors = validateExamData(examData);
 
       expect(errors.length).toBe(2);
-      expect(errors[0]).toBe('rightLightTouchC5ReasonImpairmentNotDueToSci has value Other, but the level was not marked with a star: 2');
-      expect(errors[1]).toBe('rightLightTouchC5ReasonImpairmentNotDueToSciSpecify has value Something else, but the level was not marked with a star: 2');
+      expect(errors[0]).toBe(
+        'rightLightTouchC5ReasonImpairmentNotDueToSci has value Other, but the level was not marked with a star: 2',
+      );
+      expect(errors[1]).toBe(
+        'rightLightTouchC5ReasonImpairmentNotDueToSciSpecify has value Something else, but the level was not marked with a star: 2',
+      );
     });
 
     it('should return an error if a left sensory level has a reason for impairment not due to SCI, but the level was not marked with a star', () => {
       const examData = getExamDataForAsiaE();
       examData['leftLightTouchC5ReasonImpairmentNotDueToSci'] = 'Other';
-      examData['leftLightTouchC5ReasonImpairmentNotDueToSciSpecify'] = 'Something else';
+      examData['leftLightTouchC5ReasonImpairmentNotDueToSciSpecify'] =
+        'Something else';
 
       const errors = validateExamData(examData);
 
       expect(errors.length).toBe(2);
-      expect(errors[0]).toBe('leftLightTouchC5ReasonImpairmentNotDueToSci has value Other, but the level was not marked with a star: 2');
-      expect(errors[1]).toBe('leftLightTouchC5ReasonImpairmentNotDueToSciSpecify has value Something else, but the level was not marked with a star: 2');
+      expect(errors[0]).toBe(
+        'leftLightTouchC5ReasonImpairmentNotDueToSci has value Other, but the level was not marked with a star: 2',
+      );
+      expect(errors[1]).toBe(
+        'leftLightTouchC5ReasonImpairmentNotDueToSciSpecify has value Something else, but the level was not marked with a star: 2',
+      );
+    });
+  });
+
+  describe('bindExamDataToTotals', () => {
+    it('should bind exam data to totals', () => {
+      const examData = getExamDataForAsiaE();
+
+      const totals = bindExamDataToTotals(examData);
+
+      expect(totals).toEqual({
+        asiaImpairmentScale: '1',
+        injuryComplete: '2',
+        leftLightTouchTotal: '3',
+        leftLowerMotorTotal: '4',
+        leftMotor: '5',
+        leftMotorTotal: '6',
+        leftMotorZpp: '7',
+        leftPinPrickTotal: '8',
+        leftSensory: '9',
+        leftSensoryZpp: '10',
+        leftTouchTotal: '11',
+        leftUpperMotorTotal: '12',
+        lowerMotorTotal: '13',
+        neurologicalLevelOfInjury: '14',
+        pinPrickTotal: '15',
+        rightLightTouchTotal: '16',
+        rightLowerMotorTotal: '17',
+        rightMotor: '18',
+        rightMotorTotal: '19',
+        rightMotorZpp: '20',
+        rightPinPrickTotal: '21',
+        rightSensory: '22',
+        rightSensoryZpp: '23',
+        rightTouchTotal: '24',
+        rightUpperMotorTotal: '25',
+        touchTotal: '26',
+        upperMotorTotal: '27',
+      });
     });
 
+    it('should set an empty strign for totals not included in the exam data', () => {
+      const totals = bindExamDataToTotals({});
+
+      expect(totals).toEqual({
+        asiaImpairmentScale: '',
+        injuryComplete: '',
+        leftLightTouchTotal: '',
+        leftLowerMotorTotal: '',
+        leftMotor: '',
+        leftMotorTotal: '',
+        leftMotorZpp: '',
+        leftPinPrickTotal: '',
+        leftSensory: '',
+        leftSensoryZpp: '',
+        leftTouchTotal: '',
+        leftUpperMotorTotal: '',
+        lowerMotorTotal: '',
+        neurologicalLevelOfInjury: '',
+        pinPrickTotal: '',
+        rightLightTouchTotal: '',
+        rightLowerMotorTotal: '',
+        rightMotor: '',
+        rightMotorTotal: '',
+        rightMotorZpp: '',
+        rightPinPrickTotal: '',
+        rightSensory: '',
+        rightSensoryZpp: '',
+        rightTouchTotal: '',
+        rightUpperMotorTotal: '',
+        touchTotal: '',
+        upperMotorTotal: '',
+      });
+    });
   });
 });

--- a/src/core/helpers/examData.helper.ts
+++ b/src/core/helpers/examData.helper.ts
@@ -3,11 +3,17 @@ import {
   MotorLevel,
   MotorLevels,
   SensoryLevels,
+  Totals,
   ValidMotorValues,
   ValidSensoryValues,
 } from '@core/domain';
 
-const validateSensoryValue = (dataKey: string, examData: any, errors: string[], validValues: string[]) => {
+const validateSensoryValue = (
+  dataKey: string,
+  examData: any,
+  errors: string[],
+  validValues: string[],
+) => {
   const value = examData[dataKey];
 
   if (value && !validValues.includes(value)) {
@@ -19,42 +25,84 @@ const validateSensoryValue = (dataKey: string, examData: any, errors: string[], 
     const reasonSpecifyKey = `${dataKey}ReasonImpairmentNotDueToSciSpecify`;
 
     if (examData[reasonKey]) {
-      errors.push(`${reasonKey} has value ${examData[reasonKey]}, but the level was not marked with a star: ${value}`);
+      errors.push(
+        `${reasonKey} has value ${examData[reasonKey]}, but the level was not marked with a star: ${value}`,
+      );
     }
 
     if (examData[reasonSpecifyKey]) {
-      errors.push(`${reasonSpecifyKey} has value ${examData[reasonSpecifyKey]}, but the level was not marked with a star: ${value}`);
+      errors.push(
+        `${reasonSpecifyKey} has value ${examData[reasonSpecifyKey]}, but the level was not marked with a star: ${value}`,
+      );
     }
   }
-}
+};
 
 export const validateExamData = (examData: {[key: string]: string}) => {
   const errors: string[] = [];
 
-  SensoryLevels.forEach(level => {
-    validateSensoryValue(`rightLightTouch${level}`, examData, errors, ValidSensoryValues);
-    validateSensoryValue(`rightPinPrick${level}`, examData, errors, ValidSensoryValues);
-    validateSensoryValue(`leftLightTouch${level}`, examData, errors, ValidSensoryValues);
-    validateSensoryValue(`leftPinPrick${level}`, examData, errors, ValidSensoryValues);
+  SensoryLevels.forEach((level) => {
+    validateSensoryValue(
+      `rightLightTouch${level}`,
+      examData,
+      errors,
+      ValidSensoryValues,
+    );
+    validateSensoryValue(
+      `rightPinPrick${level}`,
+      examData,
+      errors,
+      ValidSensoryValues,
+    );
+    validateSensoryValue(
+      `leftLightTouch${level}`,
+      examData,
+      errors,
+      ValidSensoryValues,
+    );
+    validateSensoryValue(
+      `leftPinPrick${level}`,
+      examData,
+      errors,
+      ValidSensoryValues,
+    );
 
     if (MotorLevels.includes(level as MotorLevel)) {
-      validateSensoryValue(`rightMotor${level}`, examData, errors, ValidMotorValues);
-      validateSensoryValue(`leftMotor${level}`, examData, errors, ValidMotorValues);
+      validateSensoryValue(
+        `rightMotor${level}`,
+        examData,
+        errors,
+        ValidMotorValues,
+      );
+      validateSensoryValue(
+        `leftMotor${level}`,
+        examData,
+        errors,
+        ValidMotorValues,
+      );
     }
   });
 
   return errors;
 };
 
-const getCell = (name: string, dataKey: string, examData: {[key: string]: string}): Cell => {
+const getCell = (
+  name: string,
+  dataKey: string,
+  examData: {[key: string]: string},
+): Cell => {
   const value: string = examData[dataKey] ?? '';
   const hasStar = /\*/.test(value);
 
   const cell: Cell = {
     value,
     label: value.replace('**', '*'),
-    reasonImpairmentNotDueToSci: hasStar ? examData[`${dataKey}ReasonImpairmentNotDueToSci`] : undefined,
-    reasonImpairmentNotDueToSciSpecify: hasStar ? examData[`${dataKey}ReasonImpairmentNotDueToSciSpecify`] : undefined,
+    reasonImpairmentNotDueToSci: hasStar
+      ? examData[`${dataKey}ReasonImpairmentNotDueToSci`]
+      : undefined,
+    reasonImpairmentNotDueToSciSpecify: hasStar
+      ? examData[`${dataKey}ReasonImpairmentNotDueToSciSpecify`]
+      : undefined,
     name,
   };
 
@@ -65,23 +113,59 @@ const getRow = (level: string, examData: {[key: string]: string}) => {
   const isMotor = MotorLevels.includes(level as MotorLevel);
 
   return [
-    isMotor ? getCell(`right-motor-${level}`, `rightMotor${level}`, examData) : null,
+    isMotor
+      ? getCell(`right-motor-${level}`, `rightMotor${level}`, examData)
+      : null,
     getCell(`right-light-touch-${level}`, `rightLightTouch${level}`, examData),
     getCell(`right-pin-prick-${level}`, `rightPinPrick${level}`, examData),
     getCell(`left-light-touch-${level}`, `leftLightTouch${level}`, examData),
     getCell(`left-pin-prick-${level}`, `leftPinPrick${level}`, examData),
-    isMotor ? getCell(`left-motor-${level}`, `leftMotor${level}`, examData) : null,
+    isMotor
+      ? getCell(`left-motor-${level}`, `leftMotor${level}`, examData)
+      : null,
   ];
-}
+};
 
 export const bindExamDataToGridModel = (examData: {[key: string]: string}) => {
   const gridModel: Array<Cell | null>[] = [];
 
-  SensoryLevels.forEach(level => {
-    gridModel.push(
-     getRow(level, examData),
-    );
+  SensoryLevels.forEach((level) => {
+    gridModel.push(getRow(level, examData));
   });
 
   return gridModel;
+};
+
+export const bindExamDataToTotals = (examData: {
+  [key: string]: string;
+}): Totals => {
+  return {
+    asiaImpairmentScale: examData['asiaImpairmentScale'] ?? '',
+    injuryComplete: examData['injuryComplete'] ?? '',
+    leftLightTouchTotal: examData['leftLightTouchTotal'] ?? '',
+    leftLowerMotorTotal: examData['leftLowerMotorTotal'] ?? '',
+    leftMotor: examData['leftMotor'] ?? '',
+    leftMotorTotal: examData['leftMotorTotal'] ?? '',
+    leftMotorZpp: examData['leftMotorZpp'] ?? '',
+    leftPinPrickTotal: examData['leftPinPrickTotal'] ?? '',
+    leftSensory: examData['leftSensory'] ?? '',
+    leftSensoryZpp: examData['leftSensoryZpp'] ?? '',
+    leftTouchTotal: examData['leftTouchTotal'] ?? '',
+    leftUpperMotorTotal: examData['leftUpperMotorTotal'] ?? '',
+    lowerMotorTotal: examData['lowerMotorTotal'] ?? '',
+    neurologicalLevelOfInjury: examData['neurologicalLevelOfInjury'] ?? '',
+    pinPrickTotal: examData['pinPrickTotal'] ?? '',
+    rightLightTouchTotal: examData['rightLightTouchTotal'] ?? '',
+    rightLowerMotorTotal: examData['rightLowerMotorTotal'] ?? '',
+    rightMotor: examData['rightMotor'] ?? '',
+    rightMotorTotal: examData['rightMotorTotal'] ?? '',
+    rightMotorZpp: examData['rightMotorZpp'] ?? '',
+    rightPinPrickTotal: examData['rightPinPrickTotal'] ?? '',
+    rightSensory: examData['rightSensory'] ?? '',
+    rightSensoryZpp: examData['rightSensoryZpp'] ?? '',
+    rightTouchTotal: examData['rightTouchTotal'] ?? '',
+    rightUpperMotorTotal: examData['rightUpperMotorTotal'] ?? '',
+    touchTotal: examData['touchTotal'] ?? '',
+    upperMotorTotal: examData['upperMotorTotal'] ?? '',
+  };
 };

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -1,1 +1,5 @@
-export {bindExamDataToGridModel, validateExamData} from './examData.helper';
+export {
+  bindExamDataToTotals,
+  bindExamDataToGridModel,
+  validateExamData,
+} from './examData.helper';

--- a/src/core/useCases/loadExternalExamData.useCase.ts
+++ b/src/core/useCases/loadExternalExamData.useCase.ts
@@ -1,17 +1,28 @@
 import {IIsncsciAppStoreProvider} from '@core/boundaries';
-import {bindExamDataToGridModel, validateExamData} from '@core/helpers';
+import {
+  bindExamDataToGridModel,
+  bindExamDataToTotals,
+  validateExamData,
+} from '@core/helpers';
 
-export const loadExternalExamDataUseCase = async (appStoreProvider: IIsncsciAppStoreProvider, examData: {[key: string]: string}) => {
-    // 1. Validate exam data
-    const errors = validateExamData(examData);
+export const loadExternalExamDataUseCase = async (
+  appStoreProvider: IIsncsciAppStoreProvider,
+  examData: {[key: string]: string},
+) => {
+  // 1. Validate exam data
+  const errors = validateExamData(examData);
 
-    if (errors.length > 0) {
-      throw new Error(`Invalid exam data: ${errors.join(', ')}`);
-    }
+  if (errors.length > 0) {
+    throw new Error(`Invalid exam data: ${errors.join(', ')}`);
+  }
 
-    // 2. Bind exam data to a new grid model
-    const gridModel = bindExamDataToGridModel(examData);
+  // 2. Bind exam data to a new grid model
+  const gridModel = bindExamDataToGridModel(examData);
 
-    // 3. Update state
-    appStoreProvider.setGridModel(gridModel);
+  // 3. Bind exam data to the totals
+  const totals = bindExamDataToTotals(examData);
+
+  // 4. Update state
+  await appStoreProvider.setGridModel(gridModel);
+  await appStoreProvider.setTotals(totals);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ import {appStore} from '@app/store';
 import {App} from './app';
 
 import '@web/praxisIsncsciInputLayout';
+import '@web/praxisIsncsciTotals';
 
 const app = new App(appStore, new AppStoreProvider(appStore));

--- a/src/web/praxisIsncsciTotals/praxisIsncsciTotals.stories.ts
+++ b/src/web/praxisIsncsciTotals/praxisIsncsciTotals.stories.ts
@@ -30,8 +30,8 @@ const getTemplateAttributes = (args: Args) => {
 const getTemplate = (args) =>
   html`
     <praxis-isncsci-totals
-      asia-level="${args['asia-level']}"
-      complete-injury="${args['complete-injury']}"
+      asia-impairment-scale="${args['asia-impairment-scale']}"
+      injury-complete="${args['injury-complete']}"
       left-light-touch-total="${args['left-light-touch-total']}"
       left-lower-motor-total="${args['left-lower-motor-total']}"
       left-motor="${args['left-motor']}"
@@ -43,7 +43,7 @@ const getTemplate = (args) =>
       left-touch-total="${args['left-touch-total']}"
       left-upper-motor-total="${args['left-upper-motor-total']}"
       lower-motor-total="${args['lower-motor-total']}"
-      neurological-level="${args['neurological-level']}"
+      neurological-level-of-injury="${args['neurological-level-of-injury']}"
       pin-prick-total="${args['pin-prick-total']}"
       right-light-touch-total="${args['right-light-touch-total']}"
       right-lower-motor-total="${args['right-lower-motor-total']}"

--- a/src/web/praxisIsncsciTotals/praxisIsncsciTotals.ts
+++ b/src/web/praxisIsncsciTotals/praxisIsncsciTotals.ts
@@ -8,8 +8,8 @@ export class PraxisIsncsciTotals extends HTMLElement {
 
   public static get observedAttributes(): string[] {
     return [
-      'asia-level',
-      'complete-injury',
+      'asia-impairment-scale',
+      'injury-complete',
       'left-light-touch-total',
       'left-lower-motor-total',
       'left-motor',
@@ -21,7 +21,7 @@ export class PraxisIsncsciTotals extends HTMLElement {
       'left-touch-total',
       'left-upper-motor-total',
       'lower-motor-total',
-      'neurological-level',
+      'neurological-level-of-injury',
       'pin-prick-total',
       'right-light-touch-total',
       'right-lower-motor-total',
@@ -169,20 +169,20 @@ export class PraxisIsncsciTotals extends HTMLElement {
         <div>
           <div class="label-total">
             <div>Neurological level of injury (NLI)</div>
-            <div class="total" data-observation="neurological-level"></div>
+            <div class="total" data-observation="neurological-level-of-injury"></div>
           </div>
         </div>
         <div>
           <div>Complete or incomplete?</div>
           <div class="label-total">
             <div>Incomplete = Any sensory or motor funtion in S4-5</div>
-            <div class="total" data-observation="complete-injury"></div>
+            <div class="total" data-observation="injury-complete"></div>
           </div>
         </div>
         <div>
           <div class="label-total">
             <div>ASIA impairment scale (AIS)</div>
-            <div class="total" data-observation="asia-level"></div>
+            <div class="total" data-observation="asia-impairment-scale"></div>
           </div>
         </div>
         <div>


### PR DESCRIPTION
Closes #32 

## Problem

When totals are available, the app needs to update the application state and interfaces.

## Solution

When data is pushed through the `ExternalMessageProtProvider`:

1. Add a step to the `loadExternalExamDataUseCase` to update the totals in the application state
2. Have the `InputLayoutController` listen to changes to the totals and update the view

## Testing

- [x] When data is pushed through the `ExternalMessageProtProvider` the application updates the totals view

<details>
  <summary>Use case</summary</summary>

  1. Navigate to https://64f8d7c6e093108e99084a70-nhwccczgbe.chromatic.com/?path=/story/app-externalmessageportprovider--primary
  2. Press the `Load random exam` button
  3. Confirm the totals view updates

  All values are being generated randomly. By pressing the button, the system generates exam data which it passes to the app. Once received, the data goes through the process of validation and update which results in the state and views getting refreshed.

</details>