### PR TITLE
[Bug] Figma examples not sized for mobile

### DIFF
--- a/src/app/responsive-layout-milestone.mdx
+++ b/src/app/responsive-layout-milestone.mdx
@@ -1,8 +1,8 @@
-{/* responsive-layout-milestone.mdx */}
+{/* responsive-layout.mdx */}
 
 import {Canvas, Meta} from '@storybook/blocks';
 
-<Meta title="App/Milestones/1. Responsive layout milestone" />
+<Meta title="App/Milestones/1. Responsive layout" />
 
 # 1. Responsive layout
 
@@ -14,7 +14,13 @@ The new version of the ISNCSCI app must work on all devices, from mobile to desk
 The biggest design challenge is fitting all the information on a small screen while still supporting fast data entry.
 
 <iframe
-  style={{border: '1px solid rgba(0, 0, 0, 0.1);'}}
+  style={{
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    maxWidth: '800px',
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '800/940',
+  }}
   width="800"
   height="940"
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F82mMuohRV0zPWnZbZ5upup%2Fisncsci-app%3Ftype%3Ddesign%26node-id%3D800%253A76682%26mode%3Ddesign%26t%3DxrbWsAoKPNEdcQw2-1"
@@ -54,7 +60,13 @@ When collecting values flagged with a star, we may need to enter information in 
 We want those elements to remain in view.
 
 <iframe
-  style={{border: '1px solid rgba(0, 0, 0, 0.1);'}}
+  style={{
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    maxWidth: '480px',
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '480/1400',
+  }}
   width="480"
   height="1400"
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F82mMuohRV0zPWnZbZ5upup%2Fisncsci-app%3Ftype%3Ddesign%26node-id%3D814%253A16408%26mode%3Ddesign%26t%3D4nEUUAR2hPuClGd9-1"
@@ -62,7 +74,13 @@ We want those elements to remain in view.
 ></iframe>
 
 <iframe
-  style={{border: '1px solid rgba(0, 0, 0, 0.1);'}}
+  style={{
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    maxWidth: '480px',
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '480/1400',
+  }}
   width="480"
   height="1400"
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F82mMuohRV0zPWnZbZ5upup%2Fisncsci-app%3Ftype%3Ddesign%26node-id%3D847%253A30274%26mode%3Ddesign%26t%3D4nEUUAR2hPuClGd9-1"
@@ -81,7 +99,13 @@ The main reasons for this are:
 > Below is an interactive prototype showing the responsive properties of the interface. Click on it to interact with it.
 
 <iframe
-  style={{border: '1px solid rgba(0, 0, 0, 0.1);'}}
+  style={{
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    maxWidth: '800px',
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '800/560',
+  }}
   width="800"
   height="560"
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2F82mMuohRV0zPWnZbZ5upup%2Fisncsci-app%3Ftype%3Ddesign%26node-id%3D352-424643%26t%3DDbHe1lMochRm7qNa-1%26scaling%3Dcontaining%26page-id%3D207%253A9677%26starting-point-node-id%3D352%253A424643%26mode%3Ddesign&hide-ui=1"
@@ -99,7 +123,13 @@ We have redesigned the totals to be more compact and better use the space availa
 > Below: Totals modal on mobile
 
 <iframe
-  style={{border: '1px solid rgba(0, 0, 0, 0.1);'}}
+  style={{
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    maxWidth: '360px',
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '360/640',
+  }}
   width="360"
   height="640"
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F82mMuohRV0zPWnZbZ5upup%2Fisncsci-app%3Ftype%3Ddesign%26node-id%3D1004%253A31699%26mode%3Ddesign%26t%3DPP1YSdR7qyRgEEAp-1"
@@ -109,7 +139,13 @@ We have redesigned the totals to be more compact and better use the space availa
 > Below: Totals popup on larger screen
 
 <iframe
-  style={{border: '1px solid rgba(0, 0, 0, 0.1);'}}
+  style={{
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    maxWidth: '800px',
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '800/560',
+  }}
   width="800"
   height="560"
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F82mMuohRV0zPWnZbZ5upup%2Fisncsci-app%3Ftype%3Ddesign%26node-id%3D780%253A74098%26mode%3Ddesign%26t%3DPP1YSdR7qyRgEEAp-1%26scaling%3Dcontaining"


### PR DESCRIPTION
Closes #40 

## Problem

When opening the `Responsive layout milestone` entry in Storybook, the iFrames on the page are sized to large and cover the entire screen. No scrolling is possible because of it.

## Solution

Size the iFrames to 100% and leverage the max-width and aspect-ration properties to allow the frames to size and fit on both mobile and desktop.