### PR TITLE
isncsci-ui publishing pipeline

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,38 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run build
+      - run: npm run create-custom-elements-manifest:dist
+      - run: npm link
+      - run: npm link isncsci-ui
+      - run: npm test
+
+  publish-npm:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ lerna-debug.log*
 # build
 build/
 storybook-static/
+/app
+/core
+/web
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,5 @@
+{
+  "ignorePaths": ["build/**", "node_modules/**", "package-lock.json"],
+  "ignoreWords": ["xdescribe"],
+  "words": ["ESNEXT", "iife", "isncsci", "prebuild", "sourcemap", "zpp"]
+}

--- a/custom-elements-manifest-dist.config.mjs
+++ b/custom-elements-manifest-dist.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  /** Globs to analyze */
+  globs: ['web/esm/**/*.js'],
+};

--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -1,6 +1,6 @@
 export default {
   /** Globs to analyze */
-  globs: ['src/web/**/*.ts', 'src/desighSystem/**/*.ts'],
+  globs: ['src/web/**/*.ts', 'src/designSystem/**/*.ts'],
   /** Globs to exclude */
-  exclude: ['src/web/**/*.stories.ts', 'src/desighSystem/**/*.stories.ts'],
+  exclude: ['src/web/**/*.stories.ts', 'src/designSystem/**/*.stories.ts'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "praxis-isncsci-ui",
+  "name": "isncsci-ui",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "praxis-isncsci-ui",
+      "name": "isncsci-ui",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "email": "tech@praxisinstitute.org"
   },
   "bugs": {
-    "url": "https://github.com/rhi-isncsci/ui/issues"
+    "url": "https://github.com/praxis-isncsci/ui/issues"
   },
   "customElements": "custom-elements.json",
   "dependencies": {
@@ -43,6 +43,18 @@
     "tslint": "^6.1.3",
     "typescript": "^5.1.6"
   },
+  "files": [
+    "app/cjs/index.js",
+    "app/esm/index.js",
+    "core/boundaries/cjs/index.js",
+    "core/boundaries/esm/index.js",
+    "core/domain/cjs/index.js",
+    "core/domain/esm/index.js",
+    "core/useCases/cjs/index.js",
+    "core/useCases/esm/index.js",
+    "web/cjs/index.js",
+    "web/esm/index.js"
+  ],
   "homepage": "https://github.com/rhi-isncsci/ui",
   "keywords": [
     "Praxis",
@@ -55,16 +67,16 @@
     "algorithm"
   ],
   "license": "Apache-2.0",
-  "main": "./umd/index.js",
-  "module": "./index.js",
-  "name": "praxis-isncsci-ui",
+  "main": "./web/cjs/index.js",
+  "module": "./web/esm/index.js",
+  "name": "isncsci-ui",
   "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/praxis-isncsci/ui.git"
   },
   "scripts": {
-    "prebuild": "rimraf ./build",
+    "prebuild": "rimraf ./build ./app ./core ./web",
     "build": "rollup -c",
     "build-styles": "style-dictionary build --config style-dictionary.config.json",
     "start": "http-server build/ -s -c-1 -p 44333",
@@ -74,10 +86,11 @@
     "update-design-tokens": "node ./scripts/generate-token-files.ts && npm run build-styles",
     "test": "jest",
     "test:watch": "jest --watch",
-    "create-custom-elements-manifest": "custom-elements-manifest analyze"
+    "create-custom-elements-manifest": "custom-elements-manifest analyze",
+    "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
   "version": "0.0.1",
   "readme": "README.md",
-  "_id": "praxis-isncsci-ui@0.0.1"
+  "_id": "isncsci-ui@0.0.1"
 }

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,0 +1,15 @@
+import {PraxisIsncsciCell} from './praxisIsncsciCell';
+import {PraxisIsncsciGrid} from './praxisIsncsciGrid';
+import {PraxisIsncsciInputLayout} from './praxisIsncsciInputLayout';
+import {PraxisIsncsciTotals} from './praxisIsncsciTotals';
+
+[
+  PraxisIsncsciCell,
+  PraxisIsncsciGrid,
+  PraxisIsncsciInputLayout,
+  PraxisIsncsciTotals,
+].forEach((component) => {
+  if (!window.customElements.get(component.is)) {
+    window.customElements.define(component.is, component);
+  }
+});


### PR DESCRIPTION
Closes #43

## Problem

In order to use the components in a different project, like the [ISNCSCI Web project](https.isncscialgorithm.com/), the ui packages need to be deployed to NPM.

## Solution

1. Update `rollup.config.mjs` and add the configuration objects needed to build the `app`, `core`, and `web` libraries. The libraries are to be published on the root folder so we can then call `npm link` and `npm publish` from the root. We will publish `esm` and `cjs` (CommonJS) packages. We won't create an `iife` (Immediately Invoked Function Expression) as it does not seem necessary. Since the main purpose of the project is to export custom elements, we assume the developer consuming the library will favor the use of `ESM` and will implement their own exports.
2. Add `files` entries in `package.json` so that the proper files are picked on export.
3. Add a new GitHub Actions workflow to publish the package on _release_.
4. Since we are publishing folders at the root level, add the appropriate entries to `.gitignore` so that the published folders are not added to the repository.
5. Add a new Custom Elements Manifest build script that only targets the `web` project. Remember that we have been also adding the components in `Design System` so that they are picked by **StoryBook** during development.

## Testing

- [x] 1. Can publish and consume the `isncsci-ui` package

<details>
  <summary>Test case</summary>

1. As part of the development, v0.0.1 of the packages has been published using the GitHub action. On a separate project, run `npm install --save isncsci-ui`.
2. Confirm the package is available
3. Open the `isncsci-ui` folder under `npm-packages` and have a look to make sure the file structure looks correct

</details>