### PR TITLE
[Classification dialog] Close icon

### DIFF
--- a/src/web/praxisIsncsciIcon/icons/index.ts
+++ b/src/web/praxisIsncsciIcon/icons/index.ts
@@ -1,0 +1,9 @@
+import {RegularClose24} from './regularClose24';
+import {RegularClose32} from './regularClose32';
+
+export {RegularClose24, RegularClose32};
+
+export default {
+  RegularClose24,
+  RegularClose32,
+};

--- a/src/web/praxisIsncsciIcon/icons/regularClose24.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose24.ts
@@ -1,0 +1,23 @@
+/**
+ * @tagname regular-close-24
+ */
+export class RegularClose24 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-24';
+  }
+
+  private template: string = `
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 5L5 19M5 5L19 19" stroke="black" stroke-width="2"/>
+    </svg>
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose24.is, RegularClose24);

--- a/src/web/praxisIsncsciIcon/icons/regularClose32.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose32.ts
@@ -1,0 +1,24 @@
+/**
+ * @tagname regular-close-32
+ */
+export class RegularClose32 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-32';
+  }
+
+  private template: string = `
+    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M25 7L7 25" stroke="black" stroke-width="2.5"/>
+    <path d="M7 7L25 25" stroke="black" stroke-width="2.5"/>
+    </svg>  
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose32.is, RegularClose32);

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.mdx
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.mdx
@@ -1,0 +1,28 @@
+{/* praxisIsncsciIcon.mdx */}
+
+import {Canvas, Meta} from '@storybook/blocks';
+import * as Stories from './praxisIsncsciIcon.stories';
+
+<Meta of={Stories} />
+
+# Praxis ISNCSCI Icon
+
+## Problem
+
+- We need an icon component that can receive a name, theme, and size and render the appropriate SVG icon graphic
+- The element needs to be implemented in a way that only the referenced icons end up as part of the code bundle
+- The close icon is the first icon we need to support as it is needed for the classification dialog
+
+## Solution
+
+We created individual custom elements, with SVG icons as their shadow DOM, that can be referenced by name and theme using the `<praxis-isncsci-icon />` component.
+
+Example:
+
+```html
+<praxis-isncsci-icon component="regular-close-24" />
+```
+
+### Icons
+
+<Canvas of={Stories.Primary} />

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.stories.ts
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.stories.ts
@@ -1,0 +1,70 @@
+import {html} from 'lit';
+import type {Meta, StoryObj} from '@storybook/web-components';
+import './icons';
+import './praxisIsncsciIcon';
+
+const getIcon = (name: string, size: string, theme: string) => html`
+  <div class="icon">
+    <praxis-isncsci-icon
+      component="${theme}-${name}-${size}"
+    ></praxis-isncsci-icon>
+    <div class="size">${size}</div>
+  </div>
+`;
+
+const getIconCollection = (iconName: string) => html`
+  ${getIconGroup(iconName, 'regular')}
+`;
+
+const getIconGroup = (name: string, theme: string) => html`<div
+  class="icon-group"
+>
+  <div class="group-name">${theme}<br />${name}</div>
+  ${getIcon(name, '12', theme)} ${getIcon(name, '16', theme)}
+  ${getIcon(name, '20', theme)} ${getIcon(name, '24', theme)}
+  ${getIcon(name, '28', theme)} ${getIcon(name, '32', theme)}
+  ${getIcon(name, '48', theme)}
+</div>`;
+
+const meta = {
+  title: 'WebComponents/PraxisIsncsciIcon',
+  // tags: ['autodocs'],
+  render: () =>
+    html`<style>
+        .icon-grid {
+          display: flex;
+          flex-direction: row;
+        }
+
+        .icon-group {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          text-align: center;
+        }
+
+        .group-name {
+          color: #666;
+          font-size: 0.9rem;
+        }
+
+        .icon {
+          border: dashed 0.5px #999;
+          border-radius: 8px;
+          min-width: 48px;
+          min-height: 24px;
+          padding: 4px;
+        }
+
+        .icon .size {
+          color: #666;
+          font-size: 0.75rem;
+        }
+      </style>
+      <div class="icon-grid">${getIconCollection('close')}</div>`,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+export const Primary: Story = {};

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts
@@ -1,0 +1,54 @@
+/**
+ * @tagname praxis-isncsci-icon
+ */
+export class PraxisIsncsciIcon extends HTMLElement {
+  public static get is(): string {
+    return 'praxis-isncsci-icon';
+  }
+
+  public static get observedAttributes(): string[] {
+    return ['component', 'size', 'theme'];
+  }
+
+  private template = (component: string): string => `
+    <style>
+      :host {
+        --placeholder-border-radius: 4px;
+        display: inline-block;
+        color: red;
+      }
+
+      .placeholder {
+        border-radius: var(--placeholder-border-radius);
+        border: 1px solid #ccc;
+        display: inline-block;
+        height: 1em;
+        width: 1em;
+      }
+    </style>
+    ${component}
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template('<span class="placeholder"></span>');
+  }
+
+  public attributeChangedCallback(
+    name: string,
+    oldValue: string,
+    newValue: string,
+  ): void {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    if (/(component)/.test(name) && this.shadowRoot) {
+      this.shadowRoot.innerHTML = this.template(`<${newValue}></${newValue}>`);
+    }
+  }
+}
+
+window.customElements.define(PraxisIsncsciIcon.is, PraxisIsncsciIcon);


### PR DESCRIPTION
Closes #54 

## Problem

- We need an icon component that can receive a name, theme, and size and render the appropriate SVG icon graphic
- The element needs to be implemented in a way that only the referenced icons end up as part of the code bundle
- The close icon is the first icon we need to support as it is needed for the classification dialog

## Solution

I crated the `<praxis-isncsci-icon />` which receives the attribute `component` to know what icon to load. Example:

```html
<praxis-isncsci-icon component="regular-close-24"></praxis-isncsci-icon>
```

I created individual custom elements for each icon so that they can be imported when needed, this way only the icons that are being used are added to the bundle.

## Testing

1. Go to the icons entry of [Storybook](https://64f8d7c6e093108e99084a70-ykwmzqhtpl.chromatic.com/?path=/docs/webcomponents-praxisisncsciicon--docs)
2. Confirm the following icons are available:
    - `regular-close-24`
    - `regular-close-32`
