### PR TITLE
Add all supported icon sizes for `close`

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -4,6 +4,20 @@
   "modules": [
     {
       "kind": "javascript-module",
+      "path": "src/web/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "component",
+            "module": "src/web/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/web/praxisIsncsciCell/index.ts",
       "declarations": [],
       "exports": [
@@ -85,6 +99,144 @@
           "declaration": {
             "name": "PraxisIsncsciCell",
             "module": "src/web/praxisIsncsciCell/praxisIsncsciCell.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciIcon",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "component"
+            },
+            {
+              "name": "size"
+            },
+            {
+              "name": "theme"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "praxis-isncsci-icon",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciIcon",
+          "declaration": {
+            "name": "PraxisIsncsciIcon",
+            "module": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciIcon",
+            "module": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciInputLayout/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciInputLayout",
+          "declaration": {
+            "name": "PraxisIsncsciInputLayout",
+            "module": "./praxisIsncsciInputLayout"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciInputLayout",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n    <style>\n    :host {\n      --grid-gap: 4px;\n      display: flex;\n      --input-layout-mobile-breakpoint: 600px;\n    }\n\n    [right-dermatomes] {\n      margin-right: var(--grid-gap);\n    }\n\n    /*\n    [right-dermatomes],\n    [left-dermatomes] {\n      filter: drop-shadow(0 2px 2px rgba(0, 0, 0, .3));\n    }\n    */\n\n    [diagram] {\n      background-color: #E2E2E2;\n      display: none;\n      flex-grow: 1;\n    }\n\n    @media (min-width: 22.5rem) {\n      [diagram] {\n        display: block;\n      }\n    }\n    </style>\n    <div right-dermatomes>\n      <praxis-isncsci-grid></praxis-isncsci-grid>\n    </div>\n    <div diagram>Body diagram</div>\n    <div left-dermatomes>\n      <praxis-isncsci-grid left labels-hidden C5-light-touch=\"2\" C6-pin-prick=\"2\" C7-motor=\"NT\"></praxis-isncsci-grid>\n    </div>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "praxis-isncsci-input-layout",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciInputLayout",
+          "declaration": {
+            "name": "PraxisIsncsciInputLayout",
+            "module": "src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciInputLayout",
+            "module": "src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts"
           }
         }
       ]
@@ -228,79 +380,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciInputLayout/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciInputLayout",
-          "declaration": {
-            "name": "PraxisIsncsciInputLayout",
-            "module": "./praxisIsncsciInputLayout"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PraxisIsncsciInputLayout",
-          "members": [
-            {
-              "kind": "field",
-              "name": "is",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "public",
-              "static": true,
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "template",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "private",
-              "default": "`\n    <style>\n    :host {\n      --grid-gap: 4px;\n      display: flex;\n      --input-layout-mobile-breakpoint: 600px;\n    }\n\n    [right-dermatomes] {\n      margin-right: var(--grid-gap);\n    }\n\n    /*\n    [right-dermatomes],\n    [left-dermatomes] {\n      filter: drop-shadow(0 2px 2px rgba(0, 0, 0, .3));\n    }\n    */\n\n    [diagram] {\n      background-color: #E2E2E2;\n      display: none;\n      flex-grow: 1;\n    }\n\n    @media (min-width: 22.5rem) {\n      [diagram] {\n        display: block;\n      }\n    }\n    </style>\n    <div right-dermatomes>\n      <praxis-isncsci-grid></praxis-isncsci-grid>\n    </div>\n    <div diagram>Body diagram</div>\n    <div left-dermatomes>\n      <praxis-isncsci-grid left labels-hidden C5-light-touch=\"2\" C6-pin-prick=\"2\" C7-motor=\"NT\"></praxis-isncsci-grid>\n    </div>\n  `"
-            },
-            {
-              "kind": "field",
-              "name": "innerHTML"
-            }
-          ],
-          "superclass": {
-            "name": "HTMLElement"
-          },
-          "tagName": "praxis-isncsci-input-layout",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciInputLayout",
-          "declaration": {
-            "name": "PraxisIsncsciInputLayout",
-            "module": "src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "declaration": {
-            "name": "PraxisIsncsciInputLayout",
-            "module": "src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/web/praxisIsncsciTotals/index.ts",
       "declarations": [],
       "exports": [
@@ -346,10 +425,10 @@
           ],
           "attributes": [
             {
-              "name": "asia-level"
+              "name": "asia-impairment-scale"
             },
             {
-              "name": "complete-injury"
+              "name": "injury-complete"
             },
             {
               "name": "left-light-touch-total"
@@ -385,7 +464,7 @@
               "name": "lower-motor-total"
             },
             {
-              "name": "neurological-level"
+              "name": "neurological-level-of-injury"
             },
             {
               "name": "pin-prick-total"
@@ -448,6 +527,687 @@
           "declaration": {
             "name": "PraxisIsncsciTotals",
             "module": "src/web/praxisIsncsciTotals/praxisIsncsciTotals.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose12",
+          "declaration": {
+            "name": "RegularClose12",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "RegularClose16",
+          "declaration": {
+            "name": "RegularClose16",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "RegularClose20",
+          "declaration": {
+            "name": "RegularClose20",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "RegularClose24",
+          "declaration": {
+            "name": "RegularClose24",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "RegularClose28",
+          "declaration": {
+            "name": "RegularClose28",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "RegularClose32",
+          "declaration": {
+            "name": "RegularClose32",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "RegularClose48",
+          "declaration": {
+            "name": "RegularClose48",
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "default",
+          "declaration": {
+            "module": "src/web/praxisIsncsciIcon/icons/index.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose12.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose12",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n  <svg width=\"12\" height=\"12\" viewBox=\"0 0 12 12\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M9.5 2.5L2.5 9.5M2.5 2.5L9.5 9.5\" stroke=\"black\"/>\n  </svg>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-12",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose12",
+          "declaration": {
+            "name": "RegularClose12",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose12.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose12",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose12.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose16.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose16",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n  <svg width=\"16\" height=\"16\" viewBox=\"0 0 16 16\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M3 3L13 13M13 3L3 13\" stroke=\"black\" stroke-width=\"1.5\"/>\n  </svg>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-16",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose16",
+          "declaration": {
+            "name": "RegularClose16",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose16.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose16",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose16.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose20.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose20",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n  <svg width=\"20\" height=\"20\" viewBox=\"0 0 20 20\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M4.5 4.5L15.5 15.5M15.5 4.5L4.5 15.5\" stroke=\"black\" stroke-width=\"1.5\"/>\n  </svg>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-20",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose20",
+          "declaration": {
+            "name": "RegularClose20",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose20.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose20",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose20.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose24.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose24",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n    <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n    <path d=\"M19 5L5 19M5 5L19 19\" stroke=\"black\" stroke-width=\"2\"/>\n    </svg>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-24",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose24",
+          "declaration": {
+            "name": "RegularClose24",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose24.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose24",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose24.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose28.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose28",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n  <svg width=\"28\" height=\"28\" viewBox=\"0 0 28 28\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M5.5 5.5L22.5 22.5M22.5 5.5L5.5 22.5\" stroke=\"black\" stroke-width=\"2\"/>\n  </svg>  \n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-28",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose28",
+          "declaration": {
+            "name": "RegularClose28",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose28.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose28",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose28.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose32.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose32",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n    <svg width=\"32\" height=\"32\" viewBox=\"0 0 32 32\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n    <path d=\"M25 7L7 25\" stroke=\"black\" stroke-width=\"2.5\"/>\n    <path d=\"M7 7L25 25\" stroke=\"black\" stroke-width=\"2.5\"/>\n    </svg>  \n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-32",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose32",
+          "declaration": {
+            "name": "RegularClose32",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose32.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose32",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose32.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/icons/regularClose48.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "RegularClose48",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n  <svg width=\"48\" height=\"48\" viewBox=\"0 0 48 48\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M10 10L38 38M38 10L10 38\" stroke=\"black\" stroke-width=\"2\"/>\n  </svg>  \n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "regular-close-48",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "RegularClose48",
+          "declaration": {
+            "name": "RegularClose48",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose48.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "RegularClose48",
+            "module": "src/web/praxisIsncsciIcon/icons/regularClose48.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/designSystem/color/colorGroup.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "ColorGroup",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n    <style>\n      :host {\n        display: grid;\n        gap: 16px;\n        grid-template-columns: repeat(auto-fill, 124px);\n      }\n    </style>\n    <slot></slot>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "color-group",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ColorGroup",
+          "declaration": {
+            "name": "ColorGroup",
+            "module": "src/designSystem/color/colorGroup.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "ColorGroup",
+            "module": "src/designSystem/color/colorGroup.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/designSystem/color/colorSwatch.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "ColorSwatch",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n    <style>\n      :host {\n        border: solid 1px #E2E2E2;\n        display: flex;\n        flex-direction: column;\n        gap: 6px;\n        padding: 6px;\n      }\n\n      .swatch {\n        background-color: var(--swatch);\n        border: solid 1px #CCC;\n        border-radius: 3px;\n        height: 100px;\n      }\n\n      .variant,\n      .value {\n        display: block;\n        padding: 0 4px;\n      }\n\n      .variant {\n        font-weight: bold;\n      }\n\n      .value {\n        text-transform: uppercase;\n      }\n\n      .token {\n        font-size: 14px;\n      }\n    </style>\n    <div class=\"swatch\"></div>\n    <slot name=\"variant\" class=\"variant\"></slot>\n    <slot name=\"value\" class=\"value\"></slot>\n    <slot name=\"token\" class=\"token\"></slot>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "color-swatch",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ColorSwatch",
+          "declaration": {
+            "name": "ColorSwatch",
+            "module": "src/designSystem/color/colorSwatch.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "ColorSwatch",
+            "module": "src/designSystem/color/colorSwatch.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/designSystem/color/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ColorGradient",
+          "declaration": {
+            "name": "ColorGradient",
+            "module": "./colorGradient/colorGradient"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ColorGroup",
+          "declaration": {
+            "name": "ColorGroup",
+            "module": "./colorGroup"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ColorSwatch",
+          "declaration": {
+            "name": "ColorSwatch",
+            "module": "./colorSwatch"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/designSystem/color/colorGradient/colorGradient.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "ColorGradient",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "`\n    <style>\n      :host {\n        border-radius: 4px;\n        box-shadow: 0 2px 4px rgba(0, 0, 0, .2);\n        display: grid;\n        gap: 0;\n        grid-template-columns: repeat(auto-fit, minmax(16px, 1fr));\n        overflow: hidden;\n      }\n    </style>\n    <slot></slot>\n  `"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "color-gradient",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ColorGradient",
+          "declaration": {
+            "name": "ColorGradient",
+            "module": "src/designSystem/color/colorGradient/colorGradient.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "ColorGradient",
+            "module": "src/designSystem/color/colorGradient/colorGradient.ts"
           }
         }
       ]

--- a/src/web/praxisIsncsciIcon/icons/index.ts
+++ b/src/web/praxisIsncsciIcon/icons/index.ts
@@ -1,9 +1,27 @@
+import {RegularClose12} from './regularClose12';
+import {RegularClose16} from './regularClose16';
+import {RegularClose20} from './regularClose20';
 import {RegularClose24} from './regularClose24';
+import {RegularClose28} from './regularClose28';
 import {RegularClose32} from './regularClose32';
+import {RegularClose48} from './regularClose48';
 
-export {RegularClose24, RegularClose32};
+export {
+  RegularClose12,
+  RegularClose16,
+  RegularClose20,
+  RegularClose24,
+  RegularClose28,
+  RegularClose32,
+  RegularClose48,
+};
 
 export default {
+  RegularClose12,
+  RegularClose16,
+  RegularClose20,
   RegularClose24,
+  RegularClose28,
   RegularClose32,
+  RegularClose48,
 };

--- a/src/web/praxisIsncsciIcon/icons/regularClose12.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose12.ts
@@ -1,0 +1,23 @@
+/**
+ * @tagname regular-close-12
+ */
+export class RegularClose12 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-12';
+  }
+
+  private template: string = `
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9.5 2.5L2.5 9.5M2.5 2.5L9.5 9.5" stroke="black"/>
+  </svg>
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose12.is, RegularClose12);

--- a/src/web/praxisIsncsciIcon/icons/regularClose16.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose16.ts
@@ -1,0 +1,23 @@
+/**
+ * @tagname regular-close-16
+ */
+export class RegularClose16 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-16';
+  }
+
+  private template: string = `
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 3L13 13M13 3L3 13" stroke="black" stroke-width="1.5"/>
+  </svg>
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose16.is, RegularClose16);

--- a/src/web/praxisIsncsciIcon/icons/regularClose20.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose20.ts
@@ -1,0 +1,23 @@
+/**
+ * @tagname regular-close-20
+ */
+export class RegularClose20 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-20';
+  }
+
+  private template: string = `
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4.5 4.5L15.5 15.5M15.5 4.5L4.5 15.5" stroke="black" stroke-width="1.5"/>
+  </svg>
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose20.is, RegularClose20);

--- a/src/web/praxisIsncsciIcon/icons/regularClose28.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose28.ts
@@ -1,0 +1,23 @@
+/**
+ * @tagname regular-close-28
+ */
+export class RegularClose28 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-28';
+  }
+
+  private template: string = `
+  <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5.5 5.5L22.5 22.5M22.5 5.5L5.5 22.5" stroke="black" stroke-width="2"/>
+  </svg>  
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose28.is, RegularClose28);

--- a/src/web/praxisIsncsciIcon/icons/regularClose48.ts
+++ b/src/web/praxisIsncsciIcon/icons/regularClose48.ts
@@ -1,0 +1,23 @@
+/**
+ * @tagname regular-close-48
+ */
+export class RegularClose48 extends HTMLElement {
+  public static get is(): string {
+    return 'regular-close-48';
+  }
+
+  private template: string = `
+  <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 10L38 38M38 10L10 38" stroke="black" stroke-width="2"/>
+  </svg>  
+  `;
+
+  public constructor() {
+    super();
+
+    const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template;
+  }
+}
+
+window.customElements.define(RegularClose48.is, RegularClose48);

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.mdx
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.mdx
@@ -16,6 +16,7 @@ import * as Stories from './praxisIsncsciIcon.stories';
 ## Solution
 
 We created individual custom elements, with SVG icons as their shadow DOM, that can be referenced by name and theme using the `<praxis-isncsci-icon />` component.
+The supported icon sizes are: `12`, `16`, `20`, `24`, `32`, and `48`.
 
 Example:
 
@@ -25,4 +26,4 @@ Example:
 
 ### Icons
 
-<Canvas of={Stories.Primary} />
+<Canvas of={Stories.Icons} />

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.stories.ts
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.stories.ts
@@ -26,45 +26,67 @@ const getIconGroup = (name: string, theme: string) => html`<div
   ${getIcon(name, '48', theme)}
 </div>`;
 
+const iconsTemplate = html`<style>
+    .icon-grid {
+      display: flex;
+      flex-direction: row;
+    }
+
+    .icon-group {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      text-align: center;
+    }
+
+    .group-name {
+      color: #666;
+      font-size: 0.9rem;
+    }
+
+    .icon {
+      border: dashed 0.5px #999;
+      border-radius: 8px;
+      min-width: 48px;
+      min-height: 24px;
+      padding: 4px;
+    }
+
+    .icon .size {
+      color: #666;
+      font-size: 0.75rem;
+    }
+  </style>
+  <div class="icon-grid">${getIconCollection('close')}</div>`;
+
 const meta = {
   title: 'WebComponents/PraxisIsncsciIcon',
-  // tags: ['autodocs'],
-  render: () =>
-    html`<style>
-        .icon-grid {
-          display: flex;
-          flex-direction: row;
-        }
-
-        .icon-group {
-          display: flex;
-          flex-direction: column;
-          gap: 4px;
-          text-align: center;
-        }
-
-        .group-name {
-          color: #666;
-          font-size: 0.9rem;
-        }
-
-        .icon {
-          border: dashed 0.5px #999;
-          border-radius: 8px;
-          min-width: 48px;
-          min-height: 24px;
-          padding: 4px;
-        }
-
-        .icon .size {
-          color: #666;
-          font-size: 0.75rem;
-        }
-      </style>
-      <div class="icon-grid">${getIconCollection('close')}</div>`,
+  render: () => iconsTemplate,
 } satisfies Meta;
 
 export default meta;
 type Story = StoryObj;
 
-export const Primary: Story = {};
+const iconNames = ['close'];
+const sizes = ['12', '16', '20', '24', '28', '32', '48'];
+const themes = ['regular'];
+
+export const Primary: Story = {
+  args: {
+    theme: themes[0],
+    iconName: iconNames[0],
+    size: sizes[3],
+  },
+  argTypes: {
+    iconName: {control: 'select', options: iconNames},
+    size: {control: 'select', options: sizes},
+    theme: {control: 'select', options: themes},
+  },
+  render: (args) =>
+    html`<praxis-isncsci-icon
+        component="${args.theme}-${args.iconName}-${args.size}"
+      ></praxis-isncsci-icon
+      >${console.log(args)}`,
+};
+
+export const Icons: Story = {render: () => iconsTemplate};

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts
@@ -7,7 +7,7 @@ export class PraxisIsncsciIcon extends HTMLElement {
   }
 
   public static get observedAttributes(): string[] {
-    return ['component', 'size', 'theme'];
+    return ['component'];
   }
 
   private template = (component: string): string => `
@@ -45,7 +45,7 @@ export class PraxisIsncsciIcon extends HTMLElement {
       return;
     }
 
-    if (/(component)/.test(name) && this.shadowRoot) {
+    if ('component' === name && this.shadowRoot) {
       this.shadowRoot.innerHTML = this.template(`<${newValue}></${newValue}>`);
     }
   }

--- a/src/web/praxisIsncsciTotals/praxisIsncsciTotals.stories.ts
+++ b/src/web/praxisIsncsciTotals/praxisIsncsciTotals.stories.ts
@@ -20,13 +20,6 @@ const getArgs = () => {
   return args;
 };
 
-const getTemplateAttributes = (args: Args) => {
-  const attributes = Object.getOwnPropertyNames(args)
-    .map((attribute) => `${attribute}="${args[attribute]}"`)
-    .join(' ');
-  return attributes;
-};
-
 const getTemplate = (args) =>
   html`
     <praxis-isncsci-totals


### PR DESCRIPTION
Closes #56 

## Problem

We only generated versions of the close icon for sizes 24 and 32. We need to add the missing supported sizes of 12, 16, 20, 28, and 48.

We also need to add a friendlier way to switch icons in StoryBook.

## Solution

I've added the extra `svg` files and icon components.
For **StoryBook** I added a _Primary_ story where the visitor can change the theme, icon name, and size using drop downs.

## Testing

- [x] 1. Can change the icon referenced by `<praxis-isncsci-icon>`

<details>
  <summary>Test case</summary>
  
  1. Navigate to the Icon `Primary` story in **StoryBook** `?path=/story/webcomponents-praxisisncsciicon--primary&args=size:48`
  2. Using the argument controls at the bottom, cycle through the different icon sizes
  3. Confirm that versions of the `close` icon exist for all supported sizes

  ![image](https://github.com/praxis-isncsci/ui/assets/1294355/ace8b846-ba00-4ce3-b148-aeb051aaf5d1)

</details>
