### PR TITLE
Export appStore and all providers along with app package

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -49,6 +49,10 @@ const getConfig = ({output = {}, plugins = [], dir = './'}) => {
   return {
     input: {
       'app/index': 'src/app/index.ts',
+      'app/providers/index': 'src/app/providers/index.ts',
+      'app/providers/externalMessagePort.provider/index':
+        'src/app/providers/externalMessagePort.provider/index.ts',
+      'app/store/index': 'src/app/store/index.ts',
       'core/boundaries/index': 'src/core/boundaries/index.ts',
       'core/domain/index': 'src/core/domain/index.ts',
       'core/useCases/index': 'src/core/useCases/index.ts',

--- a/src/app/providers/externalMessagePort.provider/index.ts
+++ b/src/app/providers/externalMessagePort.provider/index.ts
@@ -1,4 +1,3 @@
-export {AppStoreProvider} from './appStore.provider';
 export {
   ExternalMessagePortProvider,
   ExternalMessagePortProviderActions,


### PR DESCRIPTION
Closes #62 

## Problem

In order to instantiate an App, we need to pass as parameters the appStore and the providers. This is the way to customize the way the app behaves. The current exported NPM package does not export these items. We need to add them to the Rollup configuration so they get also exported.

const app = new App(appStore, new AppStoreProvider(appStore));

## Solution

I've added the following paths to the **Rollup** configuration so that their exports are also produced:

- `src/app/providers/index.ts`
- `src/app/providers/externalMessagePort.provider/index.ts`

## Testing

- [ ] 1. The system provides exports for `appStore` and all the providers in the app directory

<details>
  <summary>Test case</summary>

  1. Run `npm run build`
  2. Open the files `app/store/esm/index.js` and `app/providers/esm/index.js` created by the build script
  3. Confirm there are exports for `appStore` and the providers in the project

</details>