### PR TITLE
Added store and provider exports to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
   "files": [
     "app/cjs/index.js",
     "app/esm/index.js",
+    "app/providers/cjs/index.js",
+    "app/providers/esm/index.js",
+    "app/store/cjs/index.js",
+    "app/store/esm/index.js",
     "core/boundaries/cjs/index.js",
     "core/boundaries/esm/index.js",
     "core/domain/cjs/index.js",
@@ -90,7 +94,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "README.md",
-  "_id": "isncsci-ui@0.0.2"
+  "_id": "isncsci-ui@0.0.3"
 }


### PR DESCRIPTION
Related to #62 

## Problem

I forgot to add the new class exports to the `package.json` files entry so that they are included in the package.

## Solution

Add the following entries under files:

- "app/providers/cjs/index.js"
- "app/providers/esm/index.js"
- "app/store/cjs/index.js"
- "app/store/esm/index.js"
