### PR TITLE
Classification grid

### DIFF
--- a/assets/css/_classification-grid.css
+++ b/assets/css/_classification-grid.css
@@ -1,0 +1,16 @@
+praxis-isncsci-classification-grid {
+  --gap: var(--space-2);
+  --heading-font-family: var(--text-font-family);
+  --heading-foreground: var(--light-totals-label-foreground);
+  --heading-font-size: var(--type-scale-caption-2-font-size);
+  --heading-weight: var(--type-scale-caption-2-weight);
+  --heading-line-height: var(--type-scale-caption-2-line-height);
+}
+
+praxis-isncsci-classification-grid .col-header {
+  text-align: center;
+}
+
+praxis-isncsci-classification-grid .row-header {
+  text-align: right;
+}

--- a/assets/css/_classification-total.css
+++ b/assets/css/_classification-total.css
@@ -1,0 +1,8 @@
+praxis-isncsci-classification-total {
+  --border-color: var(--light-primary);
+  --font-family: var(--text-font-family);
+  --font-size: var(--type-scale-caption-1-font-size);
+  --font-weight: var(--type-scale-caption-1-weight);
+  --line-height: var(--type-scale-caption-1-line-height);
+  min-width: var(--totals-cell-width);
+}

--- a/assets/css/_text-scale.css
+++ b/assets/css/_text-scale.css
@@ -10,55 +10,55 @@
 .text-caption-2 {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-caption-2-font-size);
-  font-weight: var(--type-scale-caption-2-font-weight);
+  font-weight: var(--type-scale-caption-2-weight);
   line-height: var(--type-scale-caption-2-line-height);
 }
 
 .text-caption-2-strong {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-caption-2-strong-font-size);
-  font-weight: var(--type-scale-caption-2-strong-font-weight);
+  font-weight: var(--type-scale-caption-2-strong-weight);
   line-height: var(--type-scale-caption-2-strong-line-height);
 }
 
 .text-caption-1 {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-caption-1-font-size);
-  font-weight: var(--type-scale-caption-1-font-weight);
+  font-weight: var(--type-scale-caption-1-weight);
   line-height: var(--type-scale-caption-1-line-height);
 }
 
 .text-caption-1-strong {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-caption-1-strong-font-size);
-  font-weight: var(--type-scale-caption-1-strong-font-weight);
+  font-weight: var(--type-scale-caption-1-strong-weight);
   line-height: var(--type-scale-caption-1-strong-line-height);
 }
 
 .text-caption-1-stronger {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-caption-1-stronger-font-size);
-  font-weight: var(--type-scale-caption-1-stronger-font-weight);
+  font-weight: var(--type-scale-caption-1-stronger-weight);
   line-height: var(--type-scale-caption-1-stronger-line-height);
 }
 
 .text-body-1 {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-body-1-font-size);
-  font-weight: var(--type-scale-body-1-font-weight);
+  font-weight: var(--type-scale-body-1-weight);
   line-height: var(--type-scale-body-1-line-height);
 }
 
 .text-body-1-strong {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-body-1-strong-font-size);
-  font-weight: var(--type-scale-body-1-strong-font-weight);
+  font-weight: var(--type-scale-body-1-strong-weight);
   line-height: var(--type-scale-body-1-strong-line-height);
 }
 
 .text-body-1-stronger {
   font-family: var(--text-font-family);
   font-size: var(--type-scale-body-1-stronger-font-size);
-  font-weight: var(--type-scale-body-1-stronger-font-weight);
+  font-weight: var(--type-scale-body-1-stronger-weight);
   line-height: var(--type-scale-body-1-stronger-line-height);
 }

--- a/assets/css/design-system.css
+++ b/assets/css/design-system.css
@@ -1,5 +1,7 @@
 @import url('_tokens.css');
 @import url('_text-scale.css');
+@import url('_classification-grid.css');
+@import url('_classification-total.css');
 
 body {
   font-family: Inter, Candara, Segoe, Segoe UI, Optima, Arial, sans-serif;
@@ -7,7 +9,11 @@ body {
 }
 
 body.app {
-  background-image: linear-gradient(to bottom right, rgba(51, 47, 255, .2), rgba(249, 107, 252, .5));
+  background-image: linear-gradient(
+    to bottom right,
+    rgba(51, 47, 255, 0.2),
+    rgba(249, 107, 252, 0.5)
+  );
 }
 
 body.app::after {
@@ -23,7 +29,7 @@ body.app::after {
   left: 0;
   width: 100vw;
   height: 100%;
-  background-color: rgba(0, 0, 0, .5);
+  background-color: rgba(0, 0, 0, 0.5);
   z-index: -1;
 }
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -9,9 +9,10 @@
     <title>ISNCSCI Algorithm App</title>
     <meta name="description" content="Sandbox" />
     <!-- Add any global styles for body, document, etc. -->
+    <link rel="stylesheet" href="css/design-system.css" />
     <style>
       body {
-        font-family: var(--theme-font-family, 'Segoe UI', Arial, sans-serif);
+        font-family: var(--text-font-family, 'Segoe UI', Arial, sans-serif);
       }
     </style>
     <script>
@@ -20,9 +21,35 @@
   </head>
   <body class="text-body-1">
     <noscript> Please enable JavaScript to view this website. </noscript>
-    <h1>ISNCSCI Algorithm App</h1>
+    <praxis-isncsci-app-bar><button>C</button></praxis-isncsci-app-bar>
     <praxis-isncsci-input-layout></praxis-isncsci-input-layout>
-    <praxis-isncsci-totals></praxis-isncsci-totals>
+    <praxis-isncsci-totals>
+      <praxis-isncsci-classification-grid
+        slot="neurological-levels"
+        class="classification-grid"
+      >
+        <h3 slot="heading">Neurological levels</h3>
+        <div slot="grid">
+          <div>&nbsp;</div>
+          <div class="text-caption-2 col-header">R</div>
+          <div class="text-caption-2 col-header">L</div>
+          <div class="text-caption-2 row-header">Sensory</div>
+          <praxis-isncsci-classification-total data-total="right-sensory"
+            >&nbsp;</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total data-total="left-sensory"
+            >&nbsp;</praxis-isncsci-classification-total
+          >
+          <div class="text-caption-2 row-header">Motor</div>
+          <praxis-isncsci-classification-total data-total="right-motor"
+            >&nbsp;</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total data-total="left-motor"
+            >&nbsp;</praxis-isncsci-classification-total
+          >
+        </div>
+      </praxis-isncsci-classification-grid>
+    </praxis-isncsci-totals>
     <script src="scripts/bundle.js" type="module"></script>
   </body>
 </html>

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassificationGrid.mdx
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassificationGrid.mdx
@@ -1,0 +1,157 @@
+{/* PraxisIsncsciClassificationGrid.mdx */}
+
+import {Canvas, Meta} from '@storybook/blocks';
+import * as Stories from './praxisIsncsciClassificationGrid.stories';
+
+<Meta of={Stories} />
+
+# Praxis ISNCSCI Classification Grid
+
+## Design Problem
+
+The classification dialog uses grids to display the classification results.
+The grids are used to display the classification results for the motor and sensory scores, as well as the sub-scores.
+
+## Approach
+
+A grid component that can be used to display the classification results.
+We favour composition, so we are using slots to allow the user to customize the heading and the grid.
+I believe this approach will prove beneficial when we add internationalization.
+
+### Slots
+
+- `heading` - The heading of the grid
+- `grid` - The grid itself
+
+### CSS Variables
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--gap</code>
+      </td>
+      <td>Sets the distance between heading and grid</td>
+      <td>
+        <code>0.5rem</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+#### [slot="heading"]
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--heading-foreground</code>
+      </td>
+      <td>Heading text color</td>
+      <td>
+        <code>#5E5E5E</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--heading-font-family</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>sans-serif</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--heading-font-size</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>0.625rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--heading-font-weight</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>400</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--heading-line-height</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>1.875rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--heading-text-align</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>center</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+#### [slot="grid"]
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--grid-gap</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>0.25rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--grid-template-columns</code>
+      </td>
+      <td>Use it to modify the number of columns and their sizes</td>
+      <td>
+        <code>auto auto auto</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Classification grid with 3 columns
+
+<Canvas of={Stories.Primary} />
+
+### Classification grid with 4 columns
+
+<Canvas of={Stories.Subscores} />

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassificationGrid.stories.ts
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassificationGrid.stories.ts
@@ -1,0 +1,115 @@
+import {html} from 'lit';
+import type {Meta, StoryObj} from '@storybook/web-components';
+
+import '../../../assets/css/_tokens.css';
+import '../../../assets/css/_text-scale.css';
+import '../../../assets/css/_classification-total.css';
+import '../../../assets/css/_classification-grid.css';
+import './praxisIsncsciClassificationTotal';
+import './praxisIsncsciClassificationGrid';
+
+const meta = {
+  title: 'WebComponents/Classification Grid',
+  // tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+export const Primary: Story = {
+  name: 'Neurological levels',
+  render: () => html`
+    <div style="display: inline-block;">
+      <praxis-isncsci-classification-grid>
+        <h3 slot="heading">Neurological levels</h3>
+        <div slot="grid">
+          <div>&nbsp;</div>
+          <div class="text-caption-2 col-header">R</div>
+          <div class="text-caption-2 col-header">L</div>
+          <div class="text-caption-2 row-header">Sensory</div>
+          <praxis-isncsci-classification-total
+            >C4</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >C5</praxis-isncsci-classification-total
+          >
+          <div class="text-caption-2 row-header">Motor</div>
+          <praxis-isncsci-classification-total
+            >C6</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >C7</praxis-isncsci-classification-total
+          >
+        </div>
+      </praxis-isncsci-classification-grid>
+    </div>
+  `,
+};
+
+export const Subscores: Story = {
+  name: 'Subscores',
+  render: () => html`
+    <style>
+      praxis-isncsci-classification-grid {
+        --grid-template-columns: auto var(--totals-cell-width)
+          var(--totals-cell-width);
+      }
+
+      praxis-isncsci-classification-grid.sub-scores {
+        --grid-template-columns: auto var(--totals-cell-width)
+          var(--totals-cell-width) var(--totals-cell-width);
+      }
+    </style>
+    <div style="display: inline-block;">
+      <praxis-isncsci-classification-grid class="sub-scores">
+        <h3 slot="heading">Sub-scores</h3>
+        <div slot="grid">
+          <div>&nbsp;</div>
+          <div class="text-caption-2 col-header">R</div>
+          <div class="text-caption-2 col-header">L</div>
+          <div class="text-caption-2 col-header">Total</div>
+          <div class="text-caption-2 row-header">UEMS</div>
+          <praxis-isncsci-classification-total
+            >25</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >25</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >50</praxis-isncsci-classification-total
+          >
+          <div class="text-caption-2 row-header">LEMS</div>
+          <praxis-isncsci-classification-total
+            >25</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >25</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >50</praxis-isncsci-classification-total
+          >
+          <div class="text-caption-2 row-header">Light touch</div>
+          <praxis-isncsci-classification-total
+            >56</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >56</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >112</praxis-isncsci-classification-total
+          >
+          <div class="text-caption-2 row-header">Pin prick</div>
+          <praxis-isncsci-classification-total
+            >56</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >56</praxis-isncsci-classification-total
+          >
+          <praxis-isncsci-classification-total
+            >112</praxis-isncsci-classification-total
+          >
+        </div>
+      </praxis-isncsci-classification-grid>
+    </div>
+  `,
+};

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassificationGrid.ts
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassificationGrid.ts
@@ -1,0 +1,50 @@
+/**
+ * @tagname praxis-isncsci-classification-grid
+ */
+export class PraxisIsncsciClassificationGrid extends HTMLElement {
+  public static get is() {
+    return 'praxis-isncsci-classification-grid';
+  }
+
+  private template() {
+    return `
+      <style>
+        :host {
+          display: flex;
+          flex-direction: column;
+          gap: var(--gap, 0.5rem);
+        }
+
+        ::slotted([slot="heading"]) {
+          color: var(--heading-foreground, #5E5E5E);
+          font-family: var(--heading-font-family, sans-serif);
+          font-size: var(--heading-font-size, 0.625rem);
+          font-weight: var(--heading-weight, 400);
+          line-height: var(--heading-line-height, 1.875rem);
+          text-align: var(--heading-text-align, center);
+        }
+
+        ::slotted([slot="grid"]) {
+          align-items: center;
+          display: inline-grid;
+          gap: var(--grid-gap, 0.25rem);
+          grid-template-columns: var(--grid-template-columns, auto auto auto);
+        }]
+      </style>
+      <slot name="heading"></slot>
+      <slot name="grid"></slot>
+    `;
+  }
+
+  public constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template();
+  }
+}
+
+window.customElements.define(
+  PraxisIsncsciClassificationGrid.is,
+  PraxisIsncsciClassificationGrid,
+);

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassificationTotal.mdx
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassificationTotal.mdx
@@ -1,0 +1,87 @@
+{/* PraxisIsncsciClassificationTotal.mdx */}
+
+import {Canvas, Meta} from '@storybook/blocks';
+import * as Stories from './praxisIsncsciClassificationTotal.stories';
+
+<Meta of={Stories} />
+
+# Praxis ISNCSCI Classification Total
+
+## Design Problem
+
+The classification dialog uses multiple times a cell like element, with underline, to display the classification results.
+
+## Approach
+
+A grid _total_ component to store individual classification results.
+The component uses a `slot` for the content.
+
+### CSS Variables
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--border-color</code>
+      </td>
+      <td>Used for the underlining bottom border</td>
+      <td>
+        <code>rgba(0, 0, 0, 0.6)</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--font-family</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>sans-serif</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--font-size</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>0.625rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--font-weight</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>400</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--line-height</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>1.875rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--text-align</code>
+      </td>
+      <td>&nbsp;</td>
+      <td>
+        <code>center</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={Stories.Primary} />

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassificationTotal.stories.ts
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassificationTotal.stories.ts
@@ -1,0 +1,22 @@
+import {html} from 'lit';
+import type {Meta, StoryObj} from '@storybook/web-components';
+
+import '../../../assets/css/_tokens.css';
+import '../../../assets/css/_text-scale.css';
+import '../../../assets/css/_classification-total.css';
+import './praxisIsncsciClassificationTotal';
+
+const meta = {
+  title: 'WebComponents/Classification Total',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+export const Primary: Story = {
+  render: () => html`
+    <praxis-isncsci-classification-total
+      >C7</praxis-isncsci-classification-total
+    >
+  `,
+};

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassificationTotal.ts
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassificationTotal.ts
@@ -1,0 +1,39 @@
+/**
+ * @tagname praxis-isncsci-classification-total
+ */
+export class PraxisIsncsciClassificationTotal extends HTMLElement {
+  public static get is(): string {
+    return 'praxis-isncsci-classification-total';
+  }
+
+  private template() {
+    return `
+      <style>
+        :host {
+          font-family: var(--font-family, sans-serif);
+          font-size: var(--font-size, 0.625rem);
+          font-weight: var(--font-weight, 400);
+          line-height: var(--line-height, 1.875rem);
+          text-align: var(--text-align, center);
+
+          border-bottom: solid 0.0625rem var(--border-color, rgba(0, 0, 0, 0.6));
+          display: inline-block;
+          padding: 0.25rem 0;
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+
+  public constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template();
+  }
+}
+
+window.customElements.define(
+  PraxisIsncsciClassificationTotal.is,
+  PraxisIsncsciClassificationTotal,
+);


### PR DESCRIPTION
Closes #70 

## Problem

The classification dialog uses grids to display the classification results.
The grids are used to display the classification results for the motor and sensory scores, as well as the sub-scores.

## Solution

A grid component that can be used to display the classification results.
We favour composition, so we are using slots to allow the user to customize the heading and the grid.
I believe this approach will prove beneficial when we add internationalization.

## Testing

- [x] 1. Can display a classification grid

<details>
  <summary>Test case</summary>

  1. Navigate to `?path=/story/webcomponents-classification-grid--primary`
  2. Confirm that a 3 column grid is displayed following the specs in figma:

  <img alt="" width="192" src="https://github.com/praxis-isncsci/ui/assets/1294355/9bec9d07-83fd-4b6d-bef3-2ba859329f7a" />

</details>

- [x] 2. Can modify the classification grid to have 4 columns

<details>
  <summary>Test case</summary>

  1. Navigate to `?path=/story/webcomponents-classification-grid--subscores`
  2. Confirm that a 4 column grid is displayed following the specs in figma:
  3. Review the story source code
  4. Confirm that the modification was achieved mainly with CSS

  <img alt="" width="192" src="https://github.com/praxis-isncsci/ui/assets/1294355/9f784ac1-8592-49f8-b125-9c5f97964b7b" />

</details>
