### PR TITLE
Hamburger menu icon

### DIFF
--- a/assets/icons/regular.svg
+++ b/assets/icons/regular.svg
@@ -21,5 +21,40 @@
     <g id="icon-close-48">
       <path d="M10 10L38 38M38 10L10 38" stroke="black" stroke-width="2"/>
     </g>
+    <g id="icon-hamburger-menu-12">
+      <rect x="1" y="2" width="10" height="1" fill="black"/>
+      <rect x="1" y="5" width="10" height="1" fill="black"/>
+      <rect x="1" y="8" width="10" height="1" fill="black"/>
+    </g>
+    <g id="icon-hamburger-menu-16">
+      <rect x="2" y="4" width="12" height="1" fill="black"/>
+      <rect x="2" y="7" width="12" height="1" fill="black"/>
+      <rect x="2" y="10" width="12" height="1" fill="black"/>
+    </g>
+    <g id="icon-hamburger-menu-20">
+      <rect x="3" y="5" width="14" height="1" fill="black"/>
+      <rect x="3" y="9" width="14" height="1" fill="black"/>
+      <rect x="3" y="13" width="14" height="1" fill="black"/>
+    </g>
+    <g id="icon-hamburger-menu-24">
+      <rect x="2" y="5" width="20" height="2" fill="black"/>
+      <rect x="2" y="11" width="20" height="2" fill="black"/>
+      <rect x="2" y="17" width="20" height="2" fill="black"/>
+    </g>
+    <g id="icon-hamburger-menu-28">
+      <rect x="3" y="6" width="22" height="2" fill="black"/>
+      <rect x="3" y="13" width="22" height="2" fill="black"/>
+      <rect x="3" y="20" width="22" height="2" fill="black"/>
+    </g>
+    <g id="icon-hamburger-menu-32">
+      <rect x="4" y="8" width="24" height="2" fill="black"/>
+      <rect x="4" y="15" width="24" height="2" fill="black"/>
+      <rect x="4" y="22" width="24" height="2" fill="black"/>
+    </g>
+    <g id="icon-hamburger-menu-48">
+      <rect x="6" y="12" width="36" height="3" fill="black"/>
+      <rect x="6" y="22" width="36" height="3" fill="black"/>
+      <rect x="6" y="32" width="36" height="3" fill="black"/>
+    </g>
   </defs>
 </svg>

--- a/src/web/praxisIsncsciIcon/praxisIsncsciIcon.stories.ts
+++ b/src/web/praxisIsncsciIcon/praxisIsncsciIcon.stories.ts
@@ -3,6 +3,9 @@ import type {Meta, StoryObj} from '@storybook/web-components';
 import './praxisIsncsciIcon';
 
 const iconsPath = 'assets/icons';
+const iconNames = ['close', 'hamburger-menu'];
+const sizes = ['12', '16', '20', '24', '28', '32', '48'];
+const themes = ['regular'];
 
 const getIcon = (name: string, size: string, theme: string) => html`
   <div class="icon">
@@ -29,6 +32,12 @@ const getIconGroup = (name: string, theme: string) => html`<div
 </div>`;
 
 const iconsTemplate = html`<style>
+    .theme {
+      display: flex;
+      flex-direction: row;
+      gap: 8px;
+    }
+
     .icon-grid {
       display: flex;
       flex-direction: row;
@@ -59,19 +68,18 @@ const iconsTemplate = html`<style>
       font-size: 0.75rem;
     }
   </style>
-  <div class="icon-grid">${getIconCollection('close')}</div>`;
+  <div class="theme">
+    ${iconNames.map(
+      (name) => html`<div class="icon-grid">${getIconCollection(name)}</div>`,
+    )}
+  </div>`;
 
 const meta = {
   title: 'WebComponents/PraxisIsncsciIcon',
-  render: () => iconsTemplate,
 } satisfies Meta;
 
 export default meta;
 type Story = StoryObj;
-
-const iconNames = ['close'];
-const sizes = ['12', '16', '20', '24', '28', '32', '48'];
-const themes = ['regular'];
 
 export const Primary: Story = {
   args: {


### PR DESCRIPTION
Closes #73

## Problem

A _hamburger_ icon is required for the app bar menu button

## Solution

Created the icon, for all supported sizes, in [Figma](https://www.figma.com/file/82mMuohRV0zPWnZbZ5upup/isncsci-app?type=design&node-id=1668-22541&mode=design&t=IxWntaSZoZxBvsRV-0) and imported it to the project.

## Testing

- [x] 1. Hamburger menu icon is available

<details>
  <summary>Test case</summary>

  1. Go to the **StoryBook** story `?path=/story/webcomponents-praxisisncsciicon--icons`
  2. Confirm that the hamburger menu icon is available
