### PR TITLE
Dialog header

### DIFF
--- a/assets/css/_dialog-header.css
+++ b/assets/css/_dialog-header.css
@@ -1,0 +1,12 @@
+praxis-isncsci-dialog-header {
+  --gap: var(--dialog-header-gap);
+  --height: var(--dialog-header-height);
+  --padding-bottom: var(--dialog-header-padding-bottom);
+  --padding-left: var(--dialog-header-padding-left);
+  --padding-right: var(--dialog-header-padding-right);
+  --padding-top: var(--dialog-header-padding-top);
+  --title-font-family: var(--text-font-family);
+  --title-font-size: var(--type-scale-subtitle-2-font-size);
+  --title-font-weight: var(--type-scale-subtitle-2-weight);
+  --title-line-height: var(--type-scale-subtitle-2-line-height);
+}

--- a/assets/css/design-system.css
+++ b/assets/css/design-system.css
@@ -4,6 +4,7 @@
 @import url('_buttons.css');
 @import url('_classification-grid.css');
 @import url('_classification-total.css');
+@import url('_dialog-header.css');
 
 body {
   font-family: Inter, Candara, Segoe, Segoe UI, Optima, Arial, sans-serif;

--- a/src/web/praxisIsncsciDialogHeader/index.ts
+++ b/src/web/praxisIsncsciDialogHeader/index.ts
@@ -1,0 +1,1 @@
+export {PraxisIsncsciDialogHeader} from './praxisIsncsciDialogHeader';

--- a/src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.mdx
+++ b/src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.mdx
@@ -1,0 +1,128 @@
+{/* PraxisIsncsciDialogHeader.mdx */}
+
+import {Canvas, Meta} from '@storybook/blocks';
+import * as Stories from './praxisIsncsciDialogHeader.stories';
+
+<Meta of={Stories} />
+
+# Praxis ISNCSCI Dialog Header
+
+## Design Problem
+
+Dialogs, like the _classification_ dialog, require a header to display the title and close button.
+
+## Approach
+
+We are favoring composition.
+We provide a component that can be used to compose a dialog header.
+
+### Slots
+
+- `title` - Expects an element with text
+- `close` - Expects an icon button
+
+### CSS Variables
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>--height</code>
+      </td>
+      <td></td>
+      <td>
+        <code>3.5rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--gap</code>
+      </td>
+      <td></td>
+      <td>
+        <code>0.5rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--padding-bottom</code>
+      </td>
+      <td></td>
+      <td>
+        <code>0</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--padding-left</code>
+      </td>
+      <td></td>
+      <td>
+        <code>3.25rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--padding-right</code>
+      </td>
+      <td></td>
+      <td>
+        <code>0.75rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--padding-top</code>
+      </td>
+      <td></td>
+      <td>
+        <code>0</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--title-font-family</code>
+      </td>
+      <td></td>
+      <td>
+        <code>sans-serif</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--title-font-size</code>
+      </td>
+      <td></td>
+      <td>
+        <code>1rem</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--title-font-weight</code>
+      </td>
+      <td></td>
+      <td>
+        <code>400</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>--title-line-height</code>
+      </td>
+      <td></td>
+      <td>
+        <code>1.375rem</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={Stories.Primary} />

--- a/src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.stories.ts
+++ b/src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.stories.ts
@@ -1,0 +1,38 @@
+import {html} from 'lit';
+import type {Meta, StoryObj} from '@storybook/web-components';
+
+import '@web/praxisIsncsciIcon';
+import '@web/praxisIsncsciDialogHeader';
+
+import 'assets/css/_tokens.css';
+import 'assets/css/_buttons.css';
+import 'assets/css/_dialog-header.css';
+
+const iconsPath = 'assets/icons';
+
+const meta = {
+  title: 'WebComponents/Dialog header',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+export const Primary: Story = {
+  render: () =>
+    html` <div
+      dialog-header-container
+      style="box-shadow:0 2px 4px rgba(0, 0, 0, 0.16)"
+    >
+      <praxis-isncsci-dialog-header>
+        <h2 slot="title">Classification</h2>
+        <div slot="close">
+          <button class="button icon-button">
+            <praxis-isncsci-icon
+              href="${iconsPath}/regular.svg#icon-close-24"
+              size="24"
+            ></praxis-isncsci-icon>
+          </button>
+        </div>
+      </praxis-isncsci-dialog-header>
+    </div>`,
+};

--- a/src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.ts
+++ b/src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.ts
@@ -1,11 +1,9 @@
-import '@web/praxisIsncsciIcon';
-
 /**
- * @tagname praxis-isncsci-app-bar
+ * @tagname praxis-isncsci-dialog-header
  */
-export class PraxisIsncsciAppBar extends HTMLElement {
+export class PraxisIsncsciDialogHeader extends HTMLElement {
   public static get is(): string {
-    return 'praxis-isncsci-app-bar';
+    return 'praxis-isncsci-dialog-header';
   }
 
   private template() {
@@ -16,8 +14,8 @@ export class PraxisIsncsciAppBar extends HTMLElement {
           display: flex;
           flex-direction: row;
           height: var(--height, 3.5rem);
-          padding: var(--padding, 0.75rem);
-          gap: var(--gap, 1.25rem);
+          gap: var(--gap, 0.5rem);
+          padding: var(--padding-top, 0) var(--padding-right, 0.75rem) var(--padding-bottom, 0) var(--padding-left, 3.25rem);
         }
 
         ::slotted([slot="title"]) {
@@ -26,11 +24,11 @@ export class PraxisIsncsciAppBar extends HTMLElement {
           font-size: var(--title-font-size, 1rem);
           font-weight: var(--title-font-weight, 400);
           line-height: var(--title-line-height, 1.375rem);
+          text-align: center;
         }
       </style>
-      <slot name="menu-button"></slot>
       <slot name="title"></slot>
-      <slot name="actions"></slot>
+      <slot name="close"></slot>
     `;
   }
 
@@ -42,4 +40,7 @@ export class PraxisIsncsciAppBar extends HTMLElement {
   }
 }
 
-window.customElements.define(PraxisIsncsciAppBar.is, PraxisIsncsciAppBar);
+window.customElements.define(
+  PraxisIsncsciDialogHeader.is,
+  PraxisIsncsciDialogHeader,
+);


### PR DESCRIPTION
Closes #48 

## Problem

Dialogs, like the classification dialog, require a header to display the title and close button.

## Solution

A component that can be used to compose a dialog header.

## Testing

- [x] 1. Can render a dialog header

<details>
  <summary>Test case</summary>

  1. Navigate to **Storybook** story `?path=/docs/webcomponents-dialog-header--docs`
  2. Confirm that the dialog header renders according to the specifications in the [Figma file](https://www.figma.com/file/82mMuohRV0zPWnZbZ5upup/isncsci-app?type=design&node-id=645-35567&mode=design&t=eoncr2pO3k90fplq-0)

</details>
