### PR TITLE
Fix package publishing CI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - run: npm run create-custom-elements-manifest:dist
       - run: npm link
@@ -31,8 +31,9 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: npm install
       - run: npm run build
+      - run: npm run create-custom-elements-manifest:dist
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Closes #90

## Problem

The **GitHub** action `npm-publish.yml` which publishes the packages to NPM is failing with the following error message:

[npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.](https://github.com/praxis-isncsci/ui/actions/runs/6794378424/job/18470694687)

## Solution

Replace the instancess of `npm ci` with `npm install`

