### PR TITLE
Include IsncsciExamProvider in NPM package and publish as v0.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "readme": "README.md",
-  "_id": "isncsci-ui@0.0.14"
+  "_id": "isncsci-ui@0.0.15"
 }

--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -3,3 +3,4 @@ export {
   ExternalMessagePortProvider,
   ExternalMessagePortProviderActions,
 } from './externalMessagePort.provider';
+export {IsncsciExamProvider} from './isncsciExam.provider';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import {AppStoreProvider} from '@app/providers';
-import {IsncsciExamProvider} from '@app/providers/isncsciExam.provider';
+import {AppStoreProvider, IsncsciExamProvider} from '@app/providers';
 import {appStore} from '@app/store';
 import {PraxisIsncsciWebApp} from '@app/webApp';
 


### PR DESCRIPTION
Closes #106 

## Problem

I missed to include the `IsncsciExamProvider` class in the `app/providers` file and is not being included in the exported NPM package. It needs to be there so it can be instantiated when creating a new app object.

## Solution

Included the class in the index file and increased the package version to `v0.0.15` so it can be published.