### PR TITLE
[Cell input] + Regex for motor and sensory values and sensory cell

### DIFF
--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -7,9 +7,12 @@ export {
 } from './examData.helper';
 
 export {
-  validCellNameRegex,
-  lightTouchCellRegex,
-  pinPrickCellRegex,
-  motorCellRegex,
   cellLevelRegex,
+  lightTouchCellRegex,
+  motorCellRegex,
+  motorValueRegex,
+  pinPrickCellRegex,
+  sensoryCellRegex,
+  sensoryValueRegex,
+  validCellNameRegex,
 } from './regularExpressions';

--- a/src/core/helpers/regularExpressions.spec.ts
+++ b/src/core/helpers/regularExpressions.spec.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from '@jest/globals';
+import {
+  motorValueRegex,
+  sensoryCellRegex,
+  sensoryValueRegex,
+} from './regularExpressions';
+import {SensoryLevels} from '@core/domain';
+
+describe('regularExpressions', () => {
+  describe('sensoryCellRegex', () => {
+    SensoryLevels.forEach((l) => {
+      const level = l.toLowerCase();
+
+      it(`should match right-light-touch-${level}, right-pin-prick-${level}, left-light-touch-${level}, and left-pin-prick-${level}`, () => {
+        expect(
+          sensoryCellRegex.test(`right-light-touch-${level}`),
+        ).toBeTruthy();
+        expect(sensoryCellRegex.test(`right-pin-prick-${level}`)).toBeTruthy();
+        expect(sensoryCellRegex.test(`left-light-touch-${level}`)).toBeTruthy();
+        expect(sensoryCellRegex.test(`left-pin-prick-${level}`)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('motorValue', () => {
+    [
+      '0',
+      '0*',
+      '1',
+      '1*',
+      '2',
+      '2*',
+      '3',
+      '3*',
+      '4',
+      '4*',
+      '5',
+      'NT',
+      'NT*',
+      'NT**',
+    ].forEach((v) => {
+      it(`should match ${v}`, () => {
+        expect(motorValueRegex.test(v)).toBeTruthy();
+      });
+    });
+
+    ['0**', '6', '5*', 'a', 'b', '00', 'NT***'].forEach((v) => {
+      it(`should not match ${v}`, () => {
+        expect(motorValueRegex.test(v)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('sensoryValue', () => {
+    ['0', '0*', '1', '1*', '2', 'NT', 'NT*', 'NT**'].forEach((v) => {
+      it(`should match ${v}`, () => {
+        expect(sensoryValueRegex.test(v)).toBeTruthy();
+      });
+    });
+
+    ['3', '3*', '4', '4*', '5', 'a', 'b', '00', 'NT***'].forEach((v) => {
+      it(`should not match ${v}`, () => {
+        expect(sensoryValueRegex.test(v)).toBeFalsy();
+      });
+    });
+  });
+});

--- a/src/core/helpers/regularExpressions.ts
+++ b/src/core/helpers/regularExpressions.ts
@@ -4,5 +4,9 @@ export const lightTouchCellRegex =
   /^(right|left)-light-touch-(c|t|l|s)(4_5|\d{1,2})$/;
 export const pinPrickCellRegex =
   /^(right|left)-pin-prick-(c|t|l|s)(4_5|\d{1,2})$/;
-export const motorCellRegex = /^(right|left)-motor-\d$/;
+export const sensoryCellRegex =
+  /^(right|left)-(light-touch|pin-prick)-(c[2-8]|t1[0-2]|t[1-9]|l[1-5]|s[1-3]|s4_5)$/;
+export const motorCellRegex = /^(right|left)-motor-(c|t|l|s)\d$/;
 export const cellLevelRegex = /((?!-)(c|t|l|s)(4_5|\d{1,2}))$/;
+export const motorValueRegex = /^([0-4]\*?|5|NT\*{0,2})$/;
+export const sensoryValueRegex = /^(0\*?|1\*?|2|NT\*{0,2})$/;


### PR DESCRIPTION
Closes #125 

## Problem

We need a `sensoryValueRegex` and `motorValueRegex` so we can tell the type of input we are getting and validating before attempting to update the cells.

We also need a `sensoryCellRegex` to return true for  light touch or pin prick valid cell names.

- [x] `sensoryValueRegex`
- [x] `motorValueRegex`
- [x] `sensoryCellRegex`