### PR TITLE
[Cell input] Update cell values use case

### DIFF
--- a/src/app/providers/appStore.provider.ts
+++ b/src/app/providers/appStore.provider.ts
@@ -10,6 +10,14 @@ export class AppStoreProvider implements IIsncsciAppStoreProvider {
     return Promise.resolve();
   }
 
+  public setCellsValue(cellsToUpdate: Cell[], value: string): Promise<void> {
+    this.appStore.dispatch({
+      type: Actions.SET_CELLS_VALUE,
+      payload: {cellsToUpdate, value},
+    });
+    return Promise.resolve();
+  }
+
   public setGridModel(gridModel: Array<any>): Promise<void> {
     this.appStore.dispatch({type: Actions.SET_GRID_MODEL, payload: gridModel});
     return Promise.resolve();

--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -10,6 +10,7 @@ class AppStore implements IDataStore<IAppState> {
     selectedCells: [],
     selectedPoint: null,
     status: StatusCodes.NotInitialized,
+    updatedCells: [],
     totals: {
       asiaImpairmentScale: '',
       injuryComplete: '',

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -5,6 +5,7 @@ import {IActionWithPayload} from './';
 
 export class Actions {
   public static SET_ACTIVE_CELL = 'SET_ACTIVE_CELL';
+  public static SET_CELLS_VALUE = 'SET_CELLS_VALUE';
   public static SET_GRID_MODEL = 'SET_GRID_MODEL';
   public static SET_SELECTED_CELLS = 'SET_SELECTED_CELLS';
   public static SET_TOTALS = 'SET_TOTALS';
@@ -71,6 +72,20 @@ const totals = (
   }
 };
 
-export {activeCell, gridModel, selectedCells, status, totals};
+const values = (
+  state: IAppState,
+  action: IActionWithPayload<{cellsToUpdate: Cell[]; value: string}>,
+) => {
+  switch (action.type) {
+    case Actions.SET_CELLS_VALUE:
+      const cellsToUpdate = action.payload.cellsToUpdate.slice();
+      cellsToUpdate.forEach((cell) => (cell.value = action.payload.value));
+      return Object.assign({}, state, {updatedCells: cellsToUpdate.slice()});
+    default:
+      return state;
+  }
+};
 
-export default [activeCell, gridModel, selectedCells, status, totals];
+export {activeCell, gridModel, selectedCells, status, totals, values};
+
+export default [activeCell, gridModel, selectedCells, status, totals, values];

--- a/src/core/boundaries/iAppState.ts
+++ b/src/core/boundaries/iAppState.ts
@@ -13,4 +13,5 @@ export interface IAppState {
   selectedCells: Cell[];
   status: number;
   totals: Totals;
+  updatedCells: Cell[];
 }

--- a/src/core/boundaries/iIsncsciAppStore.provider.ts
+++ b/src/core/boundaries/iIsncsciAppStore.provider.ts
@@ -2,6 +2,7 @@ import {Cell, Totals} from '@core/domain';
 
 export interface IIsncsciAppStoreProvider {
   setActiveCell(cell: Cell | null): Promise<void>;
+  setCellsValue(cells: Cell[], value: string): Promise<void>;
   setGridModel(gridModel: Array<Cell | null>[]): Promise<void>;
   setSelectedCells(cells: Cell[]): Promise<void>;
   setTotals(totals: Totals): Promise<void>;

--- a/src/core/useCases/index.ts
+++ b/src/core/useCases/index.ts
@@ -1,3 +1,4 @@
 export {calculateUseCase} from './calculate.useCase';
 export {initializeAppUseCase} from './initializeApp.useCase';
 export {loadExternalExamDataUseCase} from './loadExternalExamData.useCase';
+export {setCellsValueUseCase} from './setCellsValue.useCase';

--- a/src/core/useCases/setActiveCell.useCase.spec.ts
+++ b/src/core/useCases/setActiveCell.useCase.spec.ts
@@ -24,6 +24,7 @@ describe('setActiveCell.useCase.ts', () => {
 
       appStoreProvider = {
         setActiveCell: jest.fn(() => Promise.resolve()),
+        setCellsValue: jest.fn(() => Promise.resolve()),
         setGridModel: jest.fn(() => Promise.resolve()),
         setSelectedCells: jest.fn(() => Promise.resolve()),
         setTotals: jest.fn(() => Promise.resolve()),

--- a/src/core/useCases/setCellsValue.useCase.spec.ts
+++ b/src/core/useCases/setCellsValue.useCase.spec.ts
@@ -1,0 +1,199 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+import {Cell} from '@core/domain';
+import {bindExamDataToGridModel, findCell, motorCellRegex} from '@core/helpers';
+import {setCellsValueUseCase} from './setCellsValue.useCase';
+
+describe('setCellValue.useCase.spec', () => {
+  describe('setCellValueUseCase', () => {
+    let appStoreProvider: IIsncsciAppStoreProvider;
+    let gridModel: Array<Cell | null>[] = [];
+
+    beforeEach(() => {
+      appStoreProvider = {
+        setActiveCell: jest.fn(() => Promise.resolve()),
+        setCellsValue: jest.fn(() => Promise.resolve()),
+        setGridModel: jest.fn(() => Promise.resolve()),
+        setSelectedCells: jest.fn(() => Promise.resolve()),
+        setTotals: jest.fn(() => Promise.resolve()),
+        updateStatus: jest.fn(() => Promise.resolve()),
+      };
+      gridModel = bindExamDataToGridModel({});
+      jest.resetModules();
+    });
+
+    it('should throw an invalid value error when `value` is `5*`', async () => {
+      // Arrange
+      const value = '5*';
+      const selectedCells = [findCell('right-light-touch-c2', gridModel)];
+      const propagateDown = false;
+      let errorMessage = '';
+
+      // Act
+      try {
+        await setCellsValueUseCase(
+          value,
+          selectedCells,
+          gridModel,
+          propagateDown,
+          appStoreProvider,
+        );
+      } catch (error) {
+        errorMessage = (error as Error).message;
+      }
+
+      // Assert
+      expect(errorMessage).toBe(`Invalid value: ${value}`);
+    });
+
+    it('should set the value `1` to only `left-pin-prick-c2` when only `left-pin-prick-c2` is selected, `value` is `1`, and `propagateDown` is `false`', async () => {
+      // Arrange
+      const value = '1';
+      const selectedCells = [findCell('left-pin-prick-c2', gridModel)];
+      const propagateDown = false;
+      const expectedCells = selectedCells.slice();
+
+      // Act
+      await setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        expectedCells,
+        value,
+      );
+    });
+
+    it('should not call `setCellsValue` when only `left-pin-prick-c2` is selected (sensory cell), `value` is `4` (motor value), and `propagateDown` is `true`', async () => {
+      // Arrange
+      const value = '4';
+      const selectedCells = [findCell('left-pin-prick-c2', gridModel)];
+      const propagateDown = true;
+
+      // Act
+      await setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).not.toHaveBeenCalled();
+    });
+
+    it('should set the value `1` to the entire `left-pin-prick` row when only `left-pin-prick-c2` is selected, `value` is `1`, and `propagateDown` is `true`', async () => {
+      // Arrange
+      const value = '1';
+      const selectedCells = [findCell('left-pin-prick-c2', gridModel)];
+      const propagateDown = true;
+      const expectedCells: Array<Cell | null> = [];
+
+      gridModel.forEach((row) => expectedCells.push(row[4]));
+
+      // Act
+      await setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        expectedCells,
+        value,
+      );
+    });
+
+    it('should not call `setCellsValue` `value` is `4` (motor value) and only sensory cells are selected', async () => {
+      // Arrange
+      const value = '4';
+      const selectedCells = [
+        findCell('left-light-touch-c2', gridModel),
+        findCell('left-pin-prick-c2', gridModel),
+      ];
+      const propagateDown = true;
+
+      // Act
+      await setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).not.toHaveBeenCalled();
+    });
+
+    it('should set the value `5` (motor value) to only the motor cells selected when `value` is `5` and multiple cells are selected', () => {
+      // Arrange
+      const value = '5';
+      const selectedCells = [
+        findCell('left-light-touch-c2', gridModel),
+        findCell('left-pin-prick-c2', gridModel),
+        findCell('left-motor-c5', gridModel),
+        findCell('right-motor-s1', gridModel),
+      ];
+      const propagateDown = true;
+      const expectedCells: Array<Cell | null> = [];
+
+      selectedCells.forEach((cell) => {
+        if (motorCellRegex.test(cell.name)) {
+          expectedCells.push(cell);
+        }
+      });
+
+      // Act
+      setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        expectedCells,
+        value,
+      );
+    });
+
+    it('should set the value `NT*` to all selected cells when `value` is `NT*` and multiple cells are selected, and `propagateDown` is `false`', () => {
+      // Arrange
+      const value = 'NT*';
+      const selectedCells = [
+        findCell('left-light-touch-c2', gridModel),
+        findCell('left-pin-prick-c2', gridModel),
+        findCell('left-motor-c5', gridModel),
+        findCell('right-motor-s1', gridModel),
+      ];
+      const propagateDown = false;
+
+      // Act
+      setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        selectedCells,
+        value,
+      );
+    });
+  });
+});

--- a/src/core/useCases/setCellsValue.useCase.ts
+++ b/src/core/useCases/setCellsValue.useCase.ts
@@ -1,0 +1,75 @@
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+import {Cell} from '@core/domain';
+import {
+  getCellPosition,
+  getCellRange,
+  motorValueRegex,
+  motorCellRegex,
+  sensoryCellRegex,
+  sensoryValueRegex,
+} from '@core/helpers';
+
+/*
+ * 1. Test value to make sure it is valid.
+ * 2. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
+ *  2.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
+ *  2.3. Get the range of cells to update.
+ *  2.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
+ * 3. If there is more than one cell selected or `propagateDown` is ignored:
+ *  3.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
+ * 4. If there are no cells to update, we stop. Nothing gets updated.
+ * 5. Call `appStoreProvider.setCellsValue` with the cells to update and the value.
+ */
+export const setCellsValueUseCase = async (
+  value: string,
+  selectedCells: Cell[],
+  gridModel: Array<Cell | null>[],
+  propagateDown: boolean,
+  appStoreProvider: IIsncsciAppStoreProvider,
+) => {
+  // 1. Test value to make sure it is valid
+  // Motor values are the superset of valid values
+  if (!motorValueRegex.test(value)) {
+    throw new Error(`Invalid value: ${value}`);
+  }
+
+  const isSensoryValue = sensoryValueRegex.test(value);
+
+  // 2. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
+  if (selectedCells.length === 1 && propagateDown) {
+    // 2.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
+    if (sensoryCellRegex.test(selectedCells[0].name) && !isSensoryValue) {
+      return;
+    }
+
+    // 2.3. Get the range of cells to update.
+    const {motorRange, sensoryRange} = getCellRange(
+      getCellPosition(selectedCells[0].name),
+      null,
+      gridModel,
+      true,
+    );
+
+    // 2.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
+    appStoreProvider.setCellsValue(motorRange.concat(sensoryRange), value);
+    return;
+  }
+
+  // 3. If there is more than one cell selected or `propagateDown` is ignored:
+  const cellsToUpdate: Cell[] = [];
+
+  // 3.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
+  selectedCells.forEach((selectedCell) => {
+    if (isSensoryValue || motorCellRegex.test(selectedCell.name)) {
+      cellsToUpdate.push(selectedCell);
+    }
+  });
+
+  // 4. If there are no cells to update, we stop. Nothing gets updated.
+  if (cellsToUpdate.length === 0) {
+    return;
+  }
+
+  // 5. Call `appStoreProvider.setCellsValue` with the cells to update and the value.
+  appStoreProvider.setCellsValue(cellsToUpdate, value);
+};


### PR DESCRIPTION
Closes #131 

## Problem

We want updating cell values to fulfill the following use case:

1. Test value to make sure it is valid.
2. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
 2.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
 2.3. Get the range of cells to update.
 2.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
3. If there is more than one cell selected or `propagateDown` is ignored:
 3.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
4. If there are no cells to update, we stop. Nothing gets updated.
5. Call `appStoreProvider.setCellsValue` with the cells to update and the value.

I don't want use cases to directly modify the model objects. Modifying the state should be done by the state itself via its reducers. The use case will perform all validation and select the right cells to be updated finally calling `appStoreProvider.setCellsValue`, passing the cells to be updated and value, so that the reducers can apply the changes to the state.

## Solution

* I have implemented the use case described in the problem.
* Updates to the state are done in the reducer

## Testing

Make sure that the unit tests for this use case are passing and that all possible scenarios have been covered in the tests.