### PR TITLE
VAC and DAP controls

### DIFF
--- a/assets/css/_anal-function.css
+++ b/assets/css/_anal-function.css
@@ -1,0 +1,37 @@
+.anal-function {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.anal-function select {
+  border-color: var(--light-dropdown-border, #ababab);
+  border-radius: var(--isncsci-anal-function-border-radius, 0.25rem);
+  height: var(--isncsci-anal-function-height, 2.25rem);
+  width: var(--isncsci-anal-function-width, 5rem);
+}
+
+.anal-function label {
+  display: inline-block;
+  width: auto;
+}
+
+.anal-function label .intermittent {
+  display: none;
+}
+
+.anal-function.right label {
+  text-align: right;
+}
+
+@media (min-width: 48rem) {
+  .anal-function label {
+    width: 14rem;
+  }
+
+  .anal-function label .intermittent {
+    display: inline;
+  }
+}

--- a/assets/css/design-system.css
+++ b/assets/css/design-system.css
@@ -1,5 +1,6 @@
 @import url('_tokens.css');
 @import url('_text-scale.css');
+@import url('_anal-function.css');
 @import url('_app-bar.css');
 @import url('_buttons.css');
 @import url('_cell.css');

--- a/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
+++ b/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
@@ -24,7 +24,26 @@ export const getAppLayoutTemplate = (
       </praxis-isncsci-app-bar>
       <praxis-isncsci-input-layout
         slot="input-layout"
-      ></praxis-isncsci-input-layout>
+      >
+        <div slot="vac" class="anal-function right">
+            <label for="vac"><span class="intermittent">(</span>VAC<span class="intermittent">) Voluntary anal contraction</span></label>
+            <select name="dap" id="dap">
+              <option value=""></option>
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+              <option value="nt">NT</option>
+            </select>
+        </div>
+        <div slot="dap" class="anal-function">
+          <select name="dap" id="dap">
+            <option value=""></option>
+            <option value="yes">Yes</option>
+            <option value="no">No</option>
+            <option value="nt">NT</option>
+          </select>
+          <label for="dap"><span class="intermittent">(</span>DAP<span class="intermittent">) Deep anal pressure</span></label>
+        </div>
+      </praxis-isncsci-input-layout>
       <praxis-isncsci-classification slot="classification">
         <praxis-isncsci-dialog-header slot="header">
           <h2 slot="title">Classification</h2>

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.stories.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.stories.ts
@@ -1,14 +1,35 @@
-import { html } from "lit";
-import type { Meta, StoryObj } from "@storybook/web-components";
-import "./praxisIsncsciInputLayout";
-import "/assets/css/design-system.css";
+import {html} from 'lit';
+import type {Meta, StoryObj} from '@storybook/web-components';
+import './praxisIsncsciInputLayout';
+import '/assets/css/design-system.css';
 
 // More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 const meta = {
-  title: "WebComponents/PraxisIsncsciInputLayout",
-  tags: ["autodocs"],
+  title: 'WebComponents/PraxisIsncsciInputLayout',
+  tags: ['autodocs'],
   render: () =>
-    html`<praxis-isncsci-input-layout></praxis-isncsci-grid-input-layout>`,
+    html`
+    <praxis-isncsci-input-layout>
+      <div slot="vac" class="anal-function right">
+          <label for="vac"><span class="intermittent">(</span>VAC<span class="intermittent">) Voluntary anal contraction</span></label>
+          <select name="dap" id="dap">
+            <option value=""></option>
+            <option value="yes">Yes</option>
+            <option value="no">No</option>
+            <option value="nt">NT</option>
+          </select>
+      </div>
+      <div slot="dap" class="anal-function">
+        <select name="dap" id="dap">
+          <option value=""></option>
+          <option value="yes">Yes</option>
+          <option value="no">No</option>
+          <option value="nt">NT</option>
+        </select>
+        <label for="dap"><span class="intermittent">(</span>DAP<span class="intermittent">) Deep anal pressure</span></label>
+      </div>
+    </praxis-isncsci-grid-input-layout>
+    `,
 } satisfies Meta;
 
 export default meta;

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
@@ -23,8 +23,20 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
       --input-layout-mobile-breakpoint: 600px;
     }
 
+    [right-dermatomes],
+    [left-dermatomes] {
+      display: flex;
+      flex-direction: column;
+    }
+
     [right-dermatomes] {
+      align-items: end;
       margin-right: var(--grid-gap);
+    }
+
+    [left-dermatomes] {
+      align-items: start;
+      margin-left: var(--grid-gap);
     }
 
     [diagram] {
@@ -59,10 +71,12 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
     <div grid-section>
       <div right-dermatomes>
         <praxis-isncsci-grid></praxis-isncsci-grid>
+        <slot name="vac"></slot>
       </div>
       <div diagram>Body diagram</div>
       <div left-dermatomes>
         <praxis-isncsci-grid left></praxis-isncsci-grid>
+        <slot name="dap"></slot>
       </div>
     </div>
     <praxis-isncsci-input disabled></praxis-isncsci-input>


### PR DESCRIPTION
Closes #142 
[Figma](https://www.figma.com/file/82mMuohRV0zPWnZbZ5upup/isncsci-app?type=design&node-id=578-22681&mode=design&t=JxAZIq8Q2c1Ga5xP-0)

## Problem

Implement the interface elements, defined in Figma, to capture the _Voluntary Anal Contraction VAC_ and _Deep Anal Pressure (DAP)_

## Solution

Added UI elements ad CSS styles using the design tokens from Figma.

## Testing

1. [ ] VAC and DAP UI controls are available at the bottom of the grid

<details>
  <summary>Test case</summary>

  1. Open the **Storybook** story `?path=/story/webcomponents-praxisisncsciinputlayout--primary`
  2. Make sure the story is on desktop view mode (has been reset)
  3. Scroll to the bottom
  4. Confirm the VAC and DAP UI elements are visible at the bottom of the interface
  5. Confirm the labels read:
      - _(VAC) Voluntary Anal Contraction VAC_
      - _(DAP) Deep Anal Pressure (DAP)_

</details>

---

2. [ ] Control labels are `VAC` and `DAP` on mobile

<details>
  <summary>Test case</summary>

  1. Open the **Storybook** story `?path=/story/webcomponents-praxisisncsciinputlayout--primary`
  2. Make sure the story is on desktop view mode (has been reset)

  <img alt="Figma view mode options" width="203" src="https://github.com/praxis-isncsci/ui/assets/1294355/d7a27c96-7ef7-48c7-b06b-7afbf578cf9f" />

  4. Scroll to the bottom
  5. Confirm the VAC and DAP UI elements are visible at the bottom of the interface
      - _VAC_
      - _DAP_

</details>

---