### PR TITLE
Update VAC and DAP use cases

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,7 +33,7 @@ const config: Config = {
   // ],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: "v8",
+  coverageProvider: 'v8',
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -91,8 +91,9 @@ const config: Config = {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
-      '^@app/(.*)$': '<rootDir>/src/app/$1',
-      '^@core/(.*)$': '<rootDir>/src/core/$1',
+    '^@app/(.*)$': '<rootDir>/src/app/$1',
+    '^@core/(.*)$': '<rootDir>/src/core/$1',
+    '^@testHelpers/(.*)$': '<rootDir>/src/testHelpers/$1',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/src/app/providers/appStore.provider.ts
+++ b/src/app/providers/appStore.provider.ts
@@ -1,6 +1,6 @@
 import {Actions, IDataStore} from '@app/store';
 import {IAppState, IIsncsciAppStoreProvider} from '@core/boundaries';
-import {Cell, Totals} from '@core/domain';
+import {BinaryObservation, Cell, Totals} from '@core/domain';
 
 export class AppStoreProvider implements IIsncsciAppStoreProvider {
   public constructor(private appStore: IDataStore<IAppState>) {}
@@ -30,6 +30,14 @@ export class AppStoreProvider implements IIsncsciAppStoreProvider {
 
   public setTotals(totals: Totals): Promise<void> {
     this.appStore.dispatch({type: Actions.SET_TOTALS, payload: totals});
+    return Promise.resolve();
+  }
+
+  public setVacDap(
+    vac: BinaryObservation | null,
+    dap: BinaryObservation | null,
+  ): Promise<void> {
+    this.appStore.dispatch({type: Actions.SET_VAC_DAP, payload: {vac, dap}});
     return Promise.resolve();
   }
 

--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -6,6 +6,7 @@ class AppStore implements IDataStore<IAppState> {
   private handlers: Function[] = [];
   private state: IAppState = {
     activeCell: null,
+    dap: null,
     gridModel: [],
     selectedCells: [],
     selectedPoint: null,
@@ -40,6 +41,7 @@ class AppStore implements IDataStore<IAppState> {
       touchTotal: '',
       upperMotorTotal: '',
     },
+    vac: null,
   };
 
   public subscribe(handler: Function) {

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,5 +1,5 @@
 import {IAppState} from '@core/boundaries';
-import {Cell, Totals} from '@core/domain';
+import {BinaryObservation, Cell, Totals} from '@core/domain';
 
 import {IActionWithPayload} from './';
 
@@ -9,6 +9,7 @@ export class Actions {
   public static SET_GRID_MODEL = 'SET_GRID_MODEL';
   public static SET_SELECTED_CELLS = 'SET_SELECTED_CELLS';
   public static SET_TOTALS = 'SET_TOTALS';
+  public static SET_VAC_DAP = 'SET_VAC_DAP';
   public static UPDATE_STATUS = 'UPDATE_STATUS';
 }
 
@@ -72,6 +73,24 @@ const totals = (
   }
 };
 
+const vacDap = (
+  state: IAppState,
+  action: IActionWithPayload<{
+    vac: BinaryObservation | null;
+    dap: BinaryObservation | null;
+  }>,
+) => {
+  switch (action.type) {
+    case Actions.SET_VAC_DAP:
+      return Object.assign({}, state, {
+        vac: action.payload.vac,
+        dap: action.payload.dap,
+      });
+    default:
+      return state;
+  }
+};
+
 const values = (
   state: IAppState,
   action: IActionWithPayload<{cellsToUpdate: Cell[]; value: string}>,
@@ -86,6 +105,14 @@ const values = (
   }
 };
 
-export {activeCell, gridModel, selectedCells, status, totals, values};
+export {activeCell, gridModel, selectedCells, status, totals, vacDap, values};
 
-export default [activeCell, gridModel, selectedCells, status, totals, values];
+export default [
+  activeCell,
+  gridModel,
+  selectedCells,
+  status,
+  totals,
+  vacDap,
+  values,
+];

--- a/src/core/boundaries/iAppState.ts
+++ b/src/core/boundaries/iAppState.ts
@@ -1,4 +1,5 @@
 import {Cell, Totals} from '@core/domain';
+import {BinaryObservation} from 'isncsci/cjs/interfaces';
 
 export class StatusCodes {
   public static Initializing: number = 2;
@@ -8,10 +9,12 @@ export class StatusCodes {
 
 export interface IAppState {
   activeCell: Cell | null;
+  dap: BinaryObservation | null;
   gridModel: Array<Cell | null>[];
   selectedPoint: string | null;
   selectedCells: Cell[];
   status: number;
   totals: Totals;
   updatedCells: Cell[];
+  vac: BinaryObservation | null;
 }

--- a/src/core/boundaries/iIsncsciAppStore.provider.ts
+++ b/src/core/boundaries/iIsncsciAppStore.provider.ts
@@ -1,4 +1,5 @@
 import {Cell, Totals} from '@core/domain';
+import {BinaryObservation} from '@core/domain';
 
 export interface IIsncsciAppStoreProvider {
   setActiveCell(cell: Cell | null): Promise<void>;
@@ -6,6 +7,10 @@ export interface IIsncsciAppStoreProvider {
   setGridModel(gridModel: Array<Cell | null>[]): Promise<void>;
   setSelectedCells(cells: Cell[]): Promise<void>;
   setTotals(totals: Totals): Promise<void>;
+  setVacDap(
+    vac: BinaryObservation | null,
+    dap: BinaryObservation | null,
+  ): Promise<void>;
   // clearDermatomeSelection(): Promise<void>;
   // setDermatomeValue(dermatomeName: string, value: string): Promise<void>;
   // setTotals(totals: IsncsciTotals): Promise<void>;

--- a/src/core/domain/binaryObservation.ts
+++ b/src/core/domain/binaryObservation.ts
@@ -1,0 +1,1 @@
+export type BinaryObservation = 'Yes' | 'No' | 'NT';

--- a/src/core/domain/index.ts
+++ b/src/core/domain/index.ts
@@ -1,3 +1,4 @@
+export {BinaryObservation} from './binaryObservation';
 export {Cell} from './cell';
 export {ExamData} from './examData';
 export {

--- a/src/core/useCases/setActiveCell.useCase.spec.ts
+++ b/src/core/useCases/setActiveCell.useCase.spec.ts
@@ -1,8 +1,9 @@
-import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import {beforeEach, describe, expect, it} from '@jest/globals';
 import {setActiveCellUseCase} from './setActiveCell.useCase';
 import {IIsncsciAppStoreProvider} from '@core/boundaries';
 import {Cell} from '@core/domain';
 import {bindExamDataToGridModel} from '@core/helpers';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
 
 const getEmptyCell = (name: string): Cell => {
   return {
@@ -21,15 +22,7 @@ describe('setActiveCell.useCase.ts', () => {
 
     beforeEach(() => {
       gridModel = bindExamDataToGridModel({});
-
-      appStoreProvider = {
-        setActiveCell: jest.fn(() => Promise.resolve()),
-        setCellsValue: jest.fn(() => Promise.resolve()),
-        setGridModel: jest.fn(() => Promise.resolve()),
-        setSelectedCells: jest.fn(() => Promise.resolve()),
-        setTotals: jest.fn(() => Promise.resolve()),
-        updateStatus: jest.fn(() => Promise.resolve()),
-      };
+      appStoreProvider = getAppStoreProviderMock();
     });
 
     it('should set the cell matching `cellName` as active cell and only selected cell when `cellName` is not null and selection mode is `single`', async () => {

--- a/src/core/useCases/setCellsValue.useCase.spec.ts
+++ b/src/core/useCases/setCellsValue.useCase.spec.ts
@@ -3,6 +3,7 @@ import {IIsncsciAppStoreProvider} from '@core/boundaries';
 import {Cell} from '@core/domain';
 import {bindExamDataToGridModel, findCell, motorCellRegex} from '@core/helpers';
 import {setCellsValueUseCase} from './setCellsValue.useCase';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
 
 describe('setCellValue.useCase.spec', () => {
   describe('setCellValueUseCase', () => {
@@ -10,14 +11,7 @@ describe('setCellValue.useCase.spec', () => {
     let gridModel: Array<Cell | null>[] = [];
 
     beforeEach(() => {
-      appStoreProvider = {
-        setActiveCell: jest.fn(() => Promise.resolve()),
-        setCellsValue: jest.fn(() => Promise.resolve()),
-        setGridModel: jest.fn(() => Promise.resolve()),
-        setSelectedCells: jest.fn(() => Promise.resolve()),
-        setTotals: jest.fn(() => Promise.resolve()),
-        updateStatus: jest.fn(() => Promise.resolve()),
-      };
+      appStoreProvider = getAppStoreProviderMock();
       gridModel = bindExamDataToGridModel({});
       jest.resetModules();
     });

--- a/src/core/useCases/setVacDap.spec.ts
+++ b/src/core/useCases/setVacDap.spec.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from '@jest/globals';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
+import {setVacDapUseCase} from './setVacDap.useCase';
+
+describe('setActiveCell.useCase.ts', () => {
+  describe('setActiveCellUseCase', () => {
+    it('sets the VAC and DAP values using the App Store Provider', async () => {
+      // Arrange
+      const appStoreProvider = getAppStoreProviderMock();
+
+      // Act
+      setVacDapUseCase('Yes', 'No', appStoreProvider);
+
+      // Assert
+      expect(appStoreProvider.setVacDap).toHaveBeenCalledWith('Yes', 'No');
+    });
+  });
+});

--- a/src/core/useCases/setVacDap.useCase.ts
+++ b/src/core/useCases/setVacDap.useCase.ts
@@ -1,0 +1,10 @@
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+import {BinaryObservation} from 'isncsci/cjs/interfaces';
+
+export const setVacDapUseCase = (
+  vac: BinaryObservation | null,
+  dap: BinaryObservation | null,
+  appStoreProvider: IIsncsciAppStoreProvider,
+) => {
+  appStoreProvider.setVacDap(vac, dap);
+};

--- a/src/testHelpers/appStoreProviderMocks.ts
+++ b/src/testHelpers/appStoreProviderMocks.ts
@@ -1,0 +1,14 @@
+import {jest} from '@jest/globals';
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+
+export const getAppStoreProviderMock = (): IIsncsciAppStoreProvider => {
+  return {
+    setActiveCell: jest.fn(() => Promise.resolve()),
+    setCellsValue: jest.fn(() => Promise.resolve()),
+    setGridModel: jest.fn(() => Promise.resolve()),
+    setSelectedCells: jest.fn(() => Promise.resolve()),
+    setTotals: jest.fn(() => Promise.resolve()),
+    setVacDap: jest.fn(() => Promise.resolve()),
+    updateStatus: jest.fn(() => Promise.resolve()),
+  };
+};

--- a/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
+++ b/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
@@ -27,11 +27,11 @@ export const getAppLayoutTemplate = (
       >
         <div slot="vac" class="anal-function right">
             <label for="vac"><span class="intermittent">(</span>VAC<span class="intermittent">) Voluntary anal contraction</span></label>
-            <select name="dap" id="dap">
-              <option value=""></option>
-              <option value="yes">Yes</option>
-              <option value="no">No</option>
-              <option value="nt">NT</option>
+            <select name="vac" id="vac">
+              <option value="None"></option>
+              <option value="Yes">Yes</option>
+              <option value="No">No</option>
+              <option value="NT">NT</option>
             </select>
         </div>
         <div slot="dap" class="anal-function">

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.stories.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.stories.ts
@@ -3,7 +3,6 @@ import type {Meta, StoryObj} from '@storybook/web-components';
 import './praxisIsncsciInputLayout';
 import '/assets/css/design-system.css';
 
-// More on how to set up stories at: https://storybook.js.org/docs/web-components/writing-stories/introduction
 const meta = {
   title: 'WebComponents/PraxisIsncsciInputLayout',
   tags: ['autodocs'],
@@ -21,10 +20,10 @@ const meta = {
       </div>
       <div slot="dap" class="anal-function">
         <select name="dap" id="dap">
-          <option value=""></option>
-          <option value="yes">Yes</option>
-          <option value="no">No</option>
-          <option value="nt">NT</option>
+          <option value="None"></option>
+          <option value="Yes">Yes</option>
+          <option value="No">No</option>
+          <option value="NT">NT</option>
         </select>
         <label for="dap"><span class="intermittent">(</span>DAP<span class="intermittent">) Deep anal pressure</span></label>
       </div>
@@ -35,5 +34,4 @@ const meta = {
 export default meta;
 type Story = StoryObj;
 
-// More on writing stories with args: https://storybook.js.org/docs/web-components/writing-stories/args
 export const Primary: Story = {};


### PR DESCRIPTION
Closes #143 

## Problem

The `VAC` and `DAP` drop downs need to be connected to the application state so that when they change, their values are set in the state.

- [x] Selecting a value for `VAC` and `DAP` updates the application state
- [x] When the `VAC` and `DAP` values change in the state, the drop downs update

## Solution

I added listeners for the `change` event for `VAC` and `DAP`. They call the `setVacDap.useCase` which updates the state. When the state changes, the **input layout controller** updates the components.
