### PR TITLE
Lowest non-key muscles and comments UI

### DIFF
--- a/assets/css/_extra-inputs.css
+++ b/assets/css/_extra-inputs.css
@@ -1,0 +1,17 @@
+praxis-isncsci-extra-inputs {
+  --gap: var(--space-6);
+  --header-color: var(--light-input-label-on-surface);
+  --header-font-family: var(--text-font-family);
+  --header-font-size: var(--type-scale-caption-1-strong-font-size);
+  --header-font-weight: var(--type-scale-caption-1-strong-weight);
+  --header-line-height: var(--type-scale-caption-1-strong-line-height);
+  --input-border-color: var(--light-input-border);
+  --input-border-radius: var(--input-border-radius);
+  --input-gap: var(--space-2);
+  --input-height: var(--input-height);
+  --label-color: var(--light-input-label-on-surface);
+  --label-font-family: var(--text-font-family);
+  --label-font-size: var(--type-scale-caption-1-font-size);
+  --label-font-weight: var(--type-scale-caption-1-weight);
+  --label-line-height: var(--type-scale-caption-1-line-height);
+}

--- a/assets/css/_tokens.css
+++ b/assets/css/_tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 30 Nov 2023 01:25:07 GMT
+ * Generated on Tue, 05 Dec 2023 23:39:59 GMT
  */
 
 :root {
@@ -131,26 +131,27 @@
   --breakpoint-xl: 90rem;
   --light-grid-caption-2-foreground: #5e5e5e;
   --light-grid-caption-foreground: #000000;
-  --light-grid-border-cell: #d4d4d4;
   --light-grid-border-cell-total: #ababab;
-  --light-input-label-foreground: #5e5e5e;
-  --light-input-foreground: #000000;
-  --light-foreground-catption-2: #5e5e5e;
-  --light-foreground-primary: #000000;
-  --light-foreground-caption: #000000;
-  --light-foreground-subdued: #5e5e5e;
+  --light-grid-border-cell: #d4d4d4;
+  --light-input-label-on-surface: #5e5e5e;
+  --light-input-on-surface: #000000;
+  --light-input-border: #ababab;
   --light-shadow: #5f1877;
+  --light-foreground-catption-2: #5e5e5e;
+  --light-foreground-caption: #000000;
+  --light-foreground-primary: #000000;
+  --light-foreground-subdued: #5e5e5e;
   --light-body-diagram-bg: #ababab;
   --light-body-diagram-segment-bg: #f9f9f9;
   --light-body-diagram-key-sensory-point-bg: #848484;
   --light-body-diagram-foreground: #6a6a6a;
   --light-body-diagram-guide-bg: #848484;
   --light-acrylic: rgba(255, 255, 255, 0.4000);
+  --light-primary: #a82ad1;
   --light-button-surface: rgba(255, 255, 255, 0.0000);
   --light-button-surface-hover: rgba(51, 4, 73, 0.0800);
   --light-button-on-surface: #1b1b1b;
   --light-button-surface-active: rgba(51, 4, 73, 0.1200);
-  --light-primary: #a82ad1;
   --light-on-primary: #ffffff;
   --light-error: #b8451c;
   --light-secondary: #007491;
@@ -236,6 +237,8 @@
   --type-scale-display-font-size: 4.25rem;
   --type-scale-display-font-weight: 600;
   --type-scale-display-line-height: 4.25rem;
+  --input-border-radius: .25rem;
+  --input-height: 2.25rem;
   --spacing-isncsci-grid-gap: 0;
   --isncsci-input-button-border-radius: .25rem;
   --isncsci-input-button-border-radius-none: 0;
@@ -247,6 +250,9 @@
   --isncsci-input-input-layout-mobile-up-width: 22.5rem;
   --isncsci-input-buttons-gap: .25rem;
   --isncsci-input-width: 332;
+  --isncsci-anal-function-width: 5rem;
+  --isncsci-anal-function-height: 2.25rem;
+  --isncsci-anal-function-border-radius: .25rem;
   --button-border-radius: .25rem;
   --icon-button-border-radius: .25rem;
   --icon-button-width: 2.5rem;
@@ -268,10 +274,10 @@
   --classification-gap: 2.5rem;
   --classification-padding: 1rem;
   --classification-z-index: 100;
+  --classification-total-padding-right: .5rem;
   --classification-total-padding-left: .5rem;
   --classification-total-padding-top: .25rem;
   --classification-total-padding-bottom: .25rem;
-  --classification-total-padding-right: .5rem;
   --acrylic-background-blur: 1.5rem;
   --acrylic-backdrop-filter: blur(var(--acrylic-background-blur));
   --acrylic-inner-shadow: inset 0 0 0.125rem rgba(255, 255, 255, 0.4);

--- a/assets/tokens/tokens.json
+++ b/assets/tokens/tokens.json
@@ -718,38 +718,46 @@
             }
           },
           "border": {
-            "cell": {
-              "$type": "color",
-              "$value": "{color.gray.050}"
-            },
             "cell-total": {
               "$type": "color",
               "$value": "{color.gray.100}"
+            },
+            "cell": {
+              "$type": "color",
+              "$value": "{color.gray.050}"
             }
           }
         },
         "input": {
           "label": {
-            "foreground": {
+            "on-surface": {
               "$type": "color",
               "$value": "{light.foreground.subdued}"
             }
           },
-          "foreground": {
+          "on-surface": {
             "$type": "color",
             "$value": "{light.foreground.primary}"
+          },
+          "border": {
+            "$type": "color",
+            "$value": "{color.gray.100}"
           }
+        },
+        "shadow": {
+          "$type": "color",
+          "$value": "{color.lilac.700}"
         },
         "foreground": {
           "catption-2": {
             "$type": "color",
             "$value": "{color.gray.500}"
           },
-          "primary": {
+          "caption": {
             "$type": "color",
             "$value": "{color.gray.1000}"
           },
-          "caption": {
+          "primary": {
             "$type": "color",
             "$value": "{color.gray.1000}"
           },
@@ -757,10 +765,6 @@
             "$type": "color",
             "$value": "{color.gray.500}"
           }
-        },
-        "shadow": {
-          "$type": "color",
-          "$value": "{color.lilac.700}"
         },
         "body-diagram": {
           "bg": {
@@ -788,6 +792,10 @@
           "$type": "color",
           "$value": "rgba(255, 255, 255, 0.4000)"
         },
+        "primary": {
+          "$type": "color",
+          "$value": "{color.lilac.400}"
+        },
         "button": {
           "surface": {
             "$type": "color",
@@ -805,10 +813,6 @@
             "$type": "color",
             "$value": "rgba(51, 4, 73, 0.1200)"
           }
-        },
-        "primary": {
-          "$type": "color",
-          "$value": "{color.lilac.400}"
         },
         "on-primary": {
           "$type": "color",
@@ -899,7 +903,7 @@
         "drop-down": {
           "border": {
             "$type": "color",
-            "$value": "{color.gray.100}"
+            "$value": "{light.input.border}"
           }
         },
         "acrylic-medium": {
@@ -1203,6 +1207,16 @@
           }
         }
       },
+      "input": {
+        "border-radius": {
+          "$type": "number",
+          "$value": "{border.radius.1}"
+        },
+        "height": {
+          "$type": "number",
+          "$value": "{units.rem-to-px.2_25rem}"
+        }
+      },
       "spacing": {
         "isncsci-grid-gap": {
           "$type": "number",
@@ -1254,6 +1268,20 @@
           "width": {
             "$type": "number",
             "$value": 332
+          }
+        },
+        "anal-function": {
+          "width": {
+            "$type": "number",
+            "$value": "{units.rem-to-px.5rem}"
+          },
+          "height": {
+            "$type": "number",
+            "$value": "{input.height}"
+          },
+          "border-radius": {
+            "$type": "number",
+            "$value": "{input.border-radius}"
           }
         }
       },
@@ -1356,6 +1384,10 @@
         }
       },
       "classification-total": {
+        "padding-right": {
+          "$type": "number",
+          "$value": "{space.2}"
+        },
         "padding-left": {
           "$type": "number",
           "$value": "{space.2}"
@@ -1367,10 +1399,6 @@
         "padding-bottom": {
           "$type": "number",
           "$value": "{space.1}"
-        },
-        "padding-right": {
-          "$type": "number",
-          "$value": "{space.2}"
         }
       },
       "acrylic": {

--- a/assets/tokens/tokens.value.tokens.json
+++ b/assets/tokens/tokens.value.tokens.json
@@ -28,38 +28,46 @@
         }
       },
       "border": {
-        "cell": {
-          "type": "color",
-          "value": "{color.gray.050}"
-        },
         "cell-total": {
           "type": "color",
           "value": "{color.gray.100}"
+        },
+        "cell": {
+          "type": "color",
+          "value": "{color.gray.050}"
         }
       }
     },
     "input": {
       "label": {
-        "foreground": {
+        "on-surface": {
           "type": "color",
           "value": "{light.foreground.subdued}"
         }
       },
-      "foreground": {
+      "on-surface": {
         "type": "color",
         "value": "{light.foreground.primary}"
+      },
+      "border": {
+        "type": "color",
+        "value": "{color.gray.100}"
       }
+    },
+    "shadow": {
+      "type": "color",
+      "value": "{color.lilac.700}"
     },
     "foreground": {
       "catption-2": {
         "type": "color",
         "value": "{color.gray.500}"
       },
-      "primary": {
+      "caption": {
         "type": "color",
         "value": "{color.gray.1000}"
       },
-      "caption": {
+      "primary": {
         "type": "color",
         "value": "{color.gray.1000}"
       },
@@ -67,10 +75,6 @@
         "type": "color",
         "value": "{color.gray.500}"
       }
-    },
-    "shadow": {
-      "type": "color",
-      "value": "{color.lilac.700}"
     },
     "body-diagram": {
       "bg": {
@@ -98,6 +102,10 @@
       "type": "color",
       "value": "rgba(255, 255, 255, 0.4000)"
     },
+    "primary": {
+      "type": "color",
+      "value": "{color.lilac.400}"
+    },
     "button": {
       "surface": {
         "type": "color",
@@ -115,10 +123,6 @@
         "type": "color",
         "value": "rgba(51, 4, 73, 0.1200)"
       }
-    },
-    "primary": {
-      "type": "color",
-      "value": "{color.lilac.400}"
     },
     "on-primary": {
       "type": "color",
@@ -209,7 +213,7 @@
     "drop-down": {
       "border": {
         "type": "color",
-        "value": "{color.gray.100}"
+        "value": "{light.input.border}"
       }
     },
     "acrylic-medium": {
@@ -513,6 +517,16 @@
       }
     }
   },
+  "input": {
+    "border-radius": {
+      "type": "number",
+      "value": "{border.radius.1}"
+    },
+    "height": {
+      "type": "number",
+      "value": "2.25rem"
+    }
+  },
   "spacing": {
     "isncsci-grid-gap": {
       "type": "number",
@@ -564,6 +578,20 @@
       "width": {
         "type": "number",
         "value": 332
+      }
+    },
+    "anal-function": {
+      "width": {
+        "type": "number",
+        "value": "5rem"
+      },
+      "height": {
+        "type": "number",
+        "value": "{input.height}"
+      },
+      "border-radius": {
+        "type": "number",
+        "value": "{input.border-radius}"
       }
     }
   },
@@ -666,6 +694,10 @@
     }
   },
   "classification-total": {
+    "padding-right": {
+      "type": "number",
+      "value": "{space.2}"
+    },
     "padding-left": {
       "type": "number",
       "value": "{space.2}"
@@ -677,10 +709,6 @@
     "padding-bottom": {
       "type": "number",
       "value": "{space.1}"
-    },
-    "padding-right": {
-      "type": "number",
-      "value": "{space.2}"
     }
   },
   "acrylic": {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -7,6 +7,7 @@ import {
   PraxisIsncsciClassificationTotal,
 } from './praxisIsncsciClassification';
 import {PraxisIsncsciDialogHeader} from './praxisIsncsciDialogHeader';
+import {PraxisIsncsciExtraInputs} from './praxisIsncsciExtraInputs/praxisIsncsciExtraInputs';
 import {PraxisIsncsciGrid} from './praxisIsncsciGrid';
 import {PraxisIsncsciInput} from './praxisIsncsciInput';
 import {PraxisIsncsciInputLayout} from './praxisIsncsciInputLayout';
@@ -19,6 +20,7 @@ import {PraxisIsncsciInputLayout} from './praxisIsncsciInputLayout';
   PraxisIsncsciClassificationGrid,
   PraxisIsncsciClassificationTotal,
   PraxisIsncsciDialogHeader,
+  PraxisIsncsciExtraInputs,
   PraxisIsncsciGrid,
   PraxisIsncsciInput,
   PraxisIsncsciInputLayout,

--- a/src/web/praxisIsncsciExtraInputs/index.ts
+++ b/src/web/praxisIsncsciExtraInputs/index.ts
@@ -1,0 +1,1 @@
+export {PraxisIsncsciExtraInputs} from './praxisIsncsciExtraInputs';

--- a/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.mdx
+++ b/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.mdx
@@ -1,0 +1,182 @@
+{/* PraxisIsncsciExtraInputs.mdx */}
+
+import {Canvas, Meta} from '@storybook/blocks';
+import * as Stories from './praxisIsncsciExtraInputs.stories';
+
+<Meta of={Stories} />
+
+# Praxis ISNCSCI extra inputs
+
+## Design Problem
+
+We need a component to display the extra inputs for the ISNCSCI form, which include the **comments** box and the inputs for **lowest non-key muscles with motor function**.
+
+## Approach
+
+I approached the component using composition.
+The component has all the **CSS** needed to provide the proper layout and spacing for mobile and larger breakpoints.
+Slots are used to allow the user to provide the proper **HTML** elements for the labels and inputs, giving flexibility to the developers using the component and making things easy when adding internationalization.
+
+### Slots
+
+- `comments` - Expects a `textarea` element
+- `comments-label` - Expects a `label` element
+- `left-lowest` - Expects a `select` element
+- `left-lowest-label` - Expects a `label` element
+- `non-key-muscles-header` - Expects a `div` or header element
+- `right-lowest-label` - Expects a `label` element
+- `right-lowest` - Expects a `select` element
+
+### CSS Variables
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>`--gap`</code>
+      </td>
+      <td>
+        Space between the lowest non-key muscle and the comments sections for
+        both vertical and horizontal layouts
+      </td>
+      <td>
+        <code>`1.5rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--header-color`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`#5e5e5e`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--header-font-family`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`sans-serif`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--header-font-size`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`0.75rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--header-font-weight`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`600`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--header-line-height`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`1rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--input-border-color`</code>
+      </td>
+      <td>Distance between labels and input controls</td>
+      <td>
+        <code>`#848484`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--input-border-radius`</code>
+      </td>
+      <td>Distance between labels and input controls</td>
+      <td>
+        <code>`0.125rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--input-gap`</code>
+      </td>
+      <td>Distance between labels and input controls</td>
+      <td>
+        <code>`0.5rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--input-height`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`2.26rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--label-color`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`#5e5e5e`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--label-font-family`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`sans-serif`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--label-font-size`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`0.75rem`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--label-font-weight`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`400`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--label-line-height`</code>
+      </td>
+      <td></td>
+      <td>
+        <code>`1rem`</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Canvas of={Stories.Primary} />

--- a/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.stories.ts
+++ b/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.stories.ts
@@ -20,12 +20,32 @@ const meta = {
         <label for="right-lowest" slot="right-lowest-label">Right:</label>
         <select name="right-lowest" id="right-lowest" slot="right-lowest">
           <option value="None"></option>
-          <option value="C5">C5</option>
+          <option value="0"></option>
+          <option value="4">C5 - Shoulder: Flexion, extension, abduction, adduction, internal and external rotation - Elbow: Supination</option>
+          <option value="5">C6 - Elbow: Pronation - Wrist: Flexion</option>
+          <option value="6">C7 - Finger: Flexion at proximal joint, extension. Thumb: Flexion, extension and abduction in plane of thumb</option>
+          <option value="7">C8 - Finger: Flexion at MCP joint Thumb: Opposition, adduction and abduction perpendicular to palm</option>
+          <option value="8">T1 - Finger: Abduction of the index finger</option>
+          <option value="21">L2 - Hip: Adduction</option>
+          <option value="22">L3 - Hip: External rotation</option>
+          <option value="23">L4 - Hip: Extension, abduction, internal rotation - Knee: Flexion - Ankle: Inversion and eversion - Toe: MP and IP extension</option>
+          <option value="24">L5 - Hallux and Toe: DIP and PIP flexion and abduction</option>
+          <option value="25">S1 - Hallux: Adduction</option>
         </select>
         <label for="left-lowest" slot="left-lowest-label">Left:</label>
         <select name="left-lowest" id="left-lowest" slot="left-lowest">
           <option value="None"></option>
-          <option value="C5">C5</option>
+          <option value="0"></option>
+          <option value="4">C5 - Shoulder: Flexion, extension, abduction, adduction, internal and external rotation - Elbow: Supination</option>
+          <option value="5">C6 - Elbow: Pronation - Wrist: Flexion</option>
+          <option value="6">C7 - Finger: Flexion at proximal joint, extension. Thumb: Flexion, extension and abduction in plane of thumb</option>
+          <option value="7">C8 - Finger: Flexion at MCP joint Thumb: Opposition, adduction and abduction perpendicular to palm</option>
+          <option value="8">T1 - Finger: Abduction of the index finger</option>
+          <option value="21">L2 - Hip: Adduction</option>
+          <option value="22">L3 - Hip: External rotation</option>
+          <option value="23">L4 - Hip: Extension, abduction, internal rotation - Knee: Flexion - Ankle: Inversion and eversion - Toe: MP and IP extension</option>
+          <option value="24">L5 - Hallux and Toe: DIP and PIP flexion and abduction</option>
+          <option value="25">S1 - Hallux: Adduction</option>
         </select>
         </div>
         <label for="comments" slot="comments-label">Comments:</label>

--- a/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.stories.ts
+++ b/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.stories.ts
@@ -1,0 +1,40 @@
+import {html} from 'lit-html';
+import type {Meta, StoryObj} from '@storybook/web-components';
+import '@web/praxisIsncsciExtraInputs';
+
+import 'assets/css/_extra-inputs.css';
+
+const meta = {
+  title: 'WebComponents/PraxisIsncsciExtraInputs',
+  render: () =>
+    html`
+      <style>
+        #root-inner {
+          container-type: inline-size;
+        }
+      </style>
+      <praxis-isncsci-extra-inputs>
+        <div slot="non-key-muscles-header">
+          Lowest non-key muscle with motor function
+        </div>
+        <label for="right-lowest" slot="right-lowest-label">Right:</label>
+        <select name="right-lowest" id="right-lowest" slot="right-lowest">
+          <option value="None"></option>
+          <option value="C5">C5</option>
+        </select>
+        <label for="left-lowest" slot="left-lowest-label">Left:</label>
+        <select name="left-lowest" id="left-lowest" slot="left-lowest">
+          <option value="None"></option>
+          <option value="C5">C5</option>
+        </select>
+        </div>
+        <label for="comments" slot="comments-label">Comments:</label>
+        <textarea name="comments" id="comments" slot="comments"></textarea>
+      </praxis-isncsci-extra-inputs>
+    `,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+export const Primary: Story = {};

--- a/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts
+++ b/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts
@@ -1,0 +1,111 @@
+export class PraxisIsncsciExtraInputs extends HTMLElement {
+  public static get is(): string {
+    return 'praxis-isncsci-extra-inputs';
+  }
+
+  private template(): string {
+    return `
+      <style>
+        :host {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          gap: var(--gap, 1.5rem);
+        }
+
+        .non-key-muscles {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .non-key-muscles,
+        .non-key-muscles .inputs,
+        .comments {
+          gap: var(--input-gap, 0.5rem);
+        }
+
+        .non-key-muscles,
+        .comments {
+          width: 100%
+        }
+
+        .inputs {
+          align-items: center;
+          display: grid;
+          grid-template-columns: minmax(min-content, max-content) 1fr;
+        }
+
+        .comments {
+          display: flex;
+          flex-direction: column;
+        }
+
+        ::slotted([slot="non-key-muscles-header"]) {
+          color: var(--header-color, #5e5e5e);
+          font-family: var(--header-font-family, sans-serif);
+          font-size: var(--header-font-size, 0.75rem);
+          font-weight: var(--header-font-weight, 600);
+          line-height: var(--header-line-height, 1rem);
+        }
+
+        ::slotted(label) {
+          color: var(--label-color, #5e5e5e);
+          font-family: var(--label-font-family, sans-serif);
+          font-size: var(--label-font-size, 0.75rem);
+          font-weight: var(--label-font-weight, 400);
+          line-height: var(--label-line-height, 1rem);
+        }
+
+        ::slotted(select),
+        ::slotted(textarea) {
+          border-color: var(--input-border-color, #848484);
+          border-radius: var(--input-border-radius, 0.125rem);
+        }
+
+        ::slotted(select) {
+          height: var(--input-height, 2.26rem);
+        }
+
+        ::slotted(textarea) {
+          height: 4.625rem;
+          resize: none;
+        }
+
+        @container (min-width: 48rem) {
+          :host {
+            flex-direction: row;
+          }
+
+          .non-key-muscles,
+          .comments {
+            max-width: 22.5rem;
+          }
+        }
+      </style>
+      <div class="non-key-muscles">
+        <slot name="non-key-muscles-header"></slot>
+        <div class="inputs">
+          <slot name="right-lowest-label"></slot>
+          <slot name="right-lowest"></slot>
+          <slot name="left-lowest-label"></slot>
+          <slot name="left-lowest"></slot>
+        </div>
+      </div>
+      <div class="comments">
+        <slot name="comments-label"></slot>
+        <slot name="comments"></slot>
+      </div>
+    `;
+  }
+
+  public constructor() {
+    super();
+    const shadowRoot = this.attachShadow({mode: 'open'});
+    shadowRoot.innerHTML = this.template();
+  }
+}
+
+window.customElements.define(
+  PraxisIsncsciExtraInputs.is,
+  PraxisIsncsciExtraInputs,
+);

--- a/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts
+++ b/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts
@@ -64,6 +64,7 @@ export class PraxisIsncsciExtraInputs extends HTMLElement {
 
         ::slotted(select) {
           height: var(--input-height, 2.26rem);
+          min-width: 0;
         }
 
         ::slotted(textarea) {

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
@@ -1,3 +1,4 @@
+import '@web/praxisIsncsciExtraInputs';
 import '@web/praxisIsncsciGrid';
 import '@web/praxisIsncsciInput';
 
@@ -12,13 +13,15 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
   private template: string = `
     <style>
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-6);
       padding-bottom: 120px;
       position: relative;
     }
 
     [grid-section] {
-      --grid-gap: 4px;
+      --grid-gap: var(--space-1);
       display: flex;
       --input-layout-mobile-breakpoint: 600px;
     }
@@ -79,6 +82,24 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
         <slot name="dap"></slot>
       </div>
     </div>
+    <praxis-isncsci-extra-inputs>
+      <div slot="non-key-muscles-header">
+        Lowest non-key muscle with motor function
+      </div>
+      <label for="right-lowest" slot="right-lowest-label">Right:</label>
+      <select name="right-lowest" id="right-lowest" slot="right-lowest">
+        <option value="None"></option>
+        <option value="C5">C5</option>
+      </select>
+      <label for="left-lowest" slot="left-lowest-label">Left:</label>
+      <select name="left-lowest" id="left-lowest" slot="left-lowest">
+        <option value="None"></option>
+        <option value="C5">C5</option>
+      </select>
+      </div>
+      <label for="comments" slot="comments-label">Comments:</label>
+      <textarea name="comments" id="comments" slot="comments"></textarea>
+    </praxis-isncsci-extra-inputs>
     <praxis-isncsci-input disabled></praxis-isncsci-input>
   `;
 

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
@@ -88,13 +88,32 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
       </div>
       <label for="right-lowest" slot="right-lowest-label">Right:</label>
       <select name="right-lowest" id="right-lowest" slot="right-lowest">
-        <option value="None"></option>
-        <option value="C5">C5</option>
+        <option value="0"></option>
+        <option value="4">C5 - Shoulder: Flexion, extension, abduction, adduction, internal and external rotation - Elbow: Supination</option>
+        <option value="5">C6 - Elbow: Pronation - Wrist: Flexion</option>
+        <option value="6">C7 - Finger: Flexion at proximal joint, extension. Thumb: Flexion, extension and abduction in plane of thumb</option>
+        <option value="7">C8 - Finger: Flexion at MCP joint Thumb: Opposition, adduction and abduction perpendicular to palm</option>
+        <option value="8">T1 - Finger: Abduction of the index finger</option>
+        <option value="21">L2 - Hip: Adduction</option>
+        <option value="22">L3 - Hip: External rotation</option>
+        <option value="23">L4 - Hip: Extension, abduction, internal rotation - Knee: Flexion - Ankle: Inversion and eversion - Toe: MP and IP extension</option>
+        <option value="24">L5 - Hallux and Toe: DIP and PIP flexion and abduction</option>
+        <option value="25">S1 - Hallux: Adduction</option>
       </select>
       <label for="left-lowest" slot="left-lowest-label">Left:</label>
       <select name="left-lowest" id="left-lowest" slot="left-lowest">
         <option value="None"></option>
-        <option value="C5">C5</option>
+        <option value="0"></option>
+        <option value="4">C5 - Shoulder: Flexion, extension, abduction, adduction, internal and external rotation - Elbow: Supination</option>
+        <option value="5">C6 - Elbow: Pronation - Wrist: Flexion</option>
+        <option value="6">C7 - Finger: Flexion at proximal joint, extension. Thumb: Flexion, extension and abduction in plane of thumb</option>
+        <option value="7">C8 - Finger: Flexion at MCP joint Thumb: Opposition, adduction and abduction perpendicular to palm</option>
+        <option value="8">T1 - Finger: Abduction of the index finger</option>
+        <option value="21">L2 - Hip: Adduction</option>
+        <option value="22">L3 - Hip: External rotation</option>
+        <option value="23">L4 - Hip: Extension, abduction, internal rotation - Knee: Flexion - Ankle: Inversion and eversion - Toe: MP and IP extension</option>
+        <option value="24">L5 - Hallux and Toe: DIP and PIP flexion and abduction</option>
+        <option value="25">S1 - Hallux: Adduction</option>
       </select>
       </div>
       <label for="comments" slot="comments-label">Comments:</label>


### PR DESCRIPTION
Closes #146 

## Problem

[Figma](https://www.figma.com/file/82mMuohRV0zPWnZbZ5upup/isncsci-app?type=design&node-id=578-22681&mode=design&t=7c6Ut5KoGnrFD44a-0)

Implement the lowest non-key muscles and comments section on the UI as specified in Figma.

<img alt="Section design" width="375" src="https://github.com/praxis-isncsci/ui/assets/1294355/b2b24be5-8859-4653-8ce1-02ea47ff4f86" />

## Solution

I approached the component using composition. The component has all the **CSS** needed to provide the proper layout and spacing for mobile and larger breakpoints. Slots are used to allow the user to provide the proper **HTML** elements for the labels and inputs, giving flexibility to the developers using the component and making things easy when adding internationalization.

## Testing

- [x] 1. The component exposes **CSS** variables

<details>
  <summary>Test case</summary>

  1. Navigate to the [extra inputs story](https://64f8d7c6e093108e99084a70-rcycvdzpuo.chromatic.com/?path=/docs/webcomponents-praxisisncsciextrainputs--docs)
  2. Confirm that the **CSS** variables in the documentation are used [in the code](https://github.com/praxis-isncsci/ui/blob/e27fedf2681ebe1be1988907e806ea1a317452c2/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts) 

</details>

---

- [x] 2. Input areas are arranged in a column and are full width for breakpoint `small mobile`

<details>
  <summary>Test case</summary>

  1. Navigate to the [extra inputs story](https://64f8d7c6e093108e99084a70-rcycvdzpuo.chromatic.com/?path=/docs/webcomponents-praxisisncsciextrainputs--primary)
  2. Open the **change preview size** menu item and select the `small mobile` option

  <img alt="Change preview size menu item" width="210" src="https://github.com/praxis-isncsci/ui/assets/1294355/78218a04-2145-45d7-be26-5d252e274f33" />

  3. Confirm that the lowest non-key muscles section and comments section are arranged in a column and use the full width of the interface

</details>

---

- [x] 3. Input areas are arranged in a column and are full width for breakpoint `large mobile`

<details>
  <summary>Test case</summary>

  1. Navigate to the [extra inputs story](https://64f8d7c6e093108e99084a70-rcycvdzpuo.chromatic.com/?path=/docs/webcomponents-praxisisncsciextrainputs--primary)
  2. Open the **change preview size** menu item and select the `large mobile` option

  <img alt="Change preview size menu item" width="210" src="https://github.com/praxis-isncsci/ui/assets/1294355/78218a04-2145-45d7-be26-5d252e274f33" />

  3. Confirm that the lowest non-key muscles section and comments section are arranged in a column and use the full width of the interface

</details>

---

- [x] 4. Input areas are arranged in a row and have a max width of `360px` on tablet and larger breakpoints

<details>
  <summary>Test case</summary>

  1. Navigate to the [extra inputs story](https://64f8d7c6e093108e99084a70-rcycvdzpuo.chromatic.com/?path=/docs/webcomponents-praxisisncsciextrainputs--primary)
  2. Open the **change preview size** menu item and select the `tablet` option

  <img alt="Change preview size menu item" width="210" src="https://github.com/praxis-isncsci/ui/assets/1294355/78218a04-2145-45d7-be26-5d252e274f33" />

  3. Confirm that the lowest non-key muscles section and comments section are arranged in a row, each section has a maximum width of `360px`, and they align to the center of the interface.

</details>

---

- [x] 5. The component center aligns

<details>
  <summary>Test case</summary>

  1. Navigate to the [extra inputs story](https://64f8d7c6e093108e99084a70-rcycvdzpuo.chromatic.com/?path=/docs/webcomponents-praxisisncsciextrainputs--docs)
  2. Confirm that the component aligns to the center of the page

</details>

---

- [x] 6. The component uses composition and exposes slots for header, labels, and input controls

<details>
  <summary>Test case</summary>

  1. Navigate to the [extra inputs story](https://64f8d7c6e093108e99084a70-rcycvdzpuo.chromatic.com/?path=/docs/webcomponents-praxisisncsciextrainputs--docs)
  2. Confirm that the **slot** elements in the documentation are used [in the code](https://github.com/praxis-isncsci/ui/blob/e27fedf2681ebe1be1988907e806ea1a317452c2/src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts) 

</details>

---
