### PR TITLE
Add readonly attributes to web components

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -18,6 +18,233 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciAppBar/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciAppBar",
+          "declaration": {
+            "name": "PraxisIsncsciAppBar",
+            "module": "./praxisIsncsciAppBar"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciAppBar/praxisIsncsciAppBar.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciAppBar",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "template",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "praxis-isncsci-app-bar",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciAppBar",
+          "declaration": {
+            "name": "PraxisIsncsciAppBar",
+            "module": "src/web/praxisIsncsciAppBar/praxisIsncsciAppBar.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciAppBar",
+            "module": "src/web/praxisIsncsciAppBar/praxisIsncsciAppBar.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "getInputLayoutTemplate",
+          "return": {
+            "type": {
+              "text": "string"
+            }
+          }
+        },
+        {
+          "kind": "function",
+          "name": "getAppLayoutTemplate",
+          "return": {
+            "type": {
+              "text": "string"
+            }
+          },
+          "parameters": [
+            {
+              "name": "classificationStyle",
+              "type": {
+                "text": "'' | 'visible' | 'static'"
+              }
+            },
+            {
+              "name": "iconsPath",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "readonly",
+              "default": "false",
+              "type": {
+                "text": "boolean"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "getInputLayoutTemplate",
+          "declaration": {
+            "name": "getInputLayoutTemplate",
+            "module": "src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "getAppLayoutTemplate",
+          "declaration": {
+            "name": "getAppLayoutTemplate",
+            "module": "src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciAppLayout/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "getAppLayoutTemplate",
+          "declaration": {
+            "name": "getAppLayoutTemplate",
+            "module": "./appLayoutTemplate"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciAppLayout",
+          "declaration": {
+            "name": "PraxisIsncsciAppLayout",
+            "module": "./praxisIsncsciAppLayout"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciAppLayout",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "template",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "updateReadonly",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "readonly",
+                  "type": {
+                    "text": "boolean"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "classification-style"
+            },
+            {
+              "name": "readonly"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "praxis-isncsci-app-layout",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciAppLayout",
+          "declaration": {
+            "name": "PraxisIsncsciAppLayout",
+            "module": "src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciAppLayout",
+            "module": "src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/web/praxisIsncsciCell/index.ts",
       "declarations": [],
       "exports": [
@@ -57,7 +284,7 @@
                 "text": "string"
               },
               "privacy": "private",
-              "default": "`\n    <style>\n      :host {\n        align-items: center;\n        background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.8));\n        /*backdrop-filter: blur(150px);*/\n        box-shadow: 0 1px 2px rgba(0, 0, 0, .1);\n        border: solid .5px rgba(0, 0, 0, .2);\n        border-radius: 2px;\n        display: flex;\n        justify-content: center;\n        min-height: 32px;\n        min-width: 32px;\n        transition: all .3s ease-in-out;\n      }\n\n      :host([highlighted]) {\n        transform: scale(1.1);\n        border: solid 1px var(--highlighted-cell-border-color, orange);\n      }\n    </style>\n    <slot></slot>\n  `"
+              "default": "`\n    <style>\n      :host {\n        align-items: center;\n        background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.8));\n        /*backdrop-filter: blur(150px);*/\n        box-shadow: 0 1px 2px rgba(0, 0, 0, .1);\n        border: solid .5px rgba(0, 0, 0, .2);\n        border-radius: 2px;\n        display: flex;\n        justify-content: center;\n        min-height: 32px;\n        min-width: 32px;\n        transition: all .3s ease-in-out;\n        user-select: none;\n      }\n\n      :host([highlighted]) {\n        transform: scale(1.1);\n        border: solid 1px var(--highlighted-cell-border-color, orange);\n      }\n    </style>\n    <slot></slot>\n  `"
             },
             {
               "kind": "field",
@@ -296,188 +523,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciAppBar/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciAppBar",
-          "declaration": {
-            "name": "PraxisIsncsciAppBar",
-            "module": "./praxisIsncsciAppBar"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciAppBar/praxisIsncsciAppBar.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PraxisIsncsciAppBar",
-          "members": [
-            {
-              "kind": "field",
-              "name": "is",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "public",
-              "static": true,
-              "readonly": true
-            },
-            {
-              "kind": "method",
-              "name": "template",
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "innerHTML"
-            }
-          ],
-          "superclass": {
-            "name": "HTMLElement"
-          },
-          "tagName": "praxis-isncsci-app-bar",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciAppBar",
-          "declaration": {
-            "name": "PraxisIsncsciAppBar",
-            "module": "src/web/praxisIsncsciAppBar/praxisIsncsciAppBar.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "declaration": {
-            "name": "PraxisIsncsciAppBar",
-            "module": "src/web/praxisIsncsciAppBar/praxisIsncsciAppBar.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts",
-      "declarations": [
-        {
-          "kind": "function",
-          "name": "getAppLayoutTemplate",
-          "return": {
-            "type": {
-              "text": "string"
-            }
-          },
-          "parameters": [
-            {
-              "name": "classificationStyle",
-              "type": {
-                "text": "'' | 'visible' | 'static'"
-              }
-            },
-            {
-              "name": "iconsPath",
-              "type": {
-                "text": "string"
-              }
-            }
-          ]
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "getAppLayoutTemplate",
-          "declaration": {
-            "name": "getAppLayoutTemplate",
-            "module": "src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciAppLayout/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "getAppLayoutTemplate",
-          "declaration": {
-            "name": "getAppLayoutTemplate",
-            "module": "./appLayoutTemplate"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciAppLayout",
-          "declaration": {
-            "name": "PraxisIsncsciAppLayout",
-            "module": "./praxisIsncsciAppLayout"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PraxisIsncsciAppLayout",
-          "members": [
-            {
-              "kind": "field",
-              "name": "is",
-              "privacy": "public",
-              "static": true,
-              "readonly": true
-            },
-            {
-              "kind": "method",
-              "name": "template",
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "innerHTML"
-            }
-          ],
-          "superclass": {
-            "name": "HTMLElement"
-          },
-          "tagName": "praxis-isncsci-app-layout",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciAppLayout",
-          "declaration": {
-            "name": "PraxisIsncsciAppLayout",
-            "module": "src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "declaration": {
-            "name": "PraxisIsncsciAppLayout",
-            "module": "src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/web/praxisIsncsciDialogHeader/index.ts",
       "declarations": [],
       "exports": [
@@ -541,79 +586,6 @@
           "declaration": {
             "name": "PraxisIsncsciDialogHeader",
             "module": "src/web/praxisIsncsciDialogHeader/praxisIsncsciDialogHeader.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciIcon/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciIcon",
-          "declaration": {
-            "name": "PraxisIsncsciIcon",
-            "module": "./praxisIsncsciIcon"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "PraxisIsncsciIcon",
-          "members": [
-            {
-              "kind": "field",
-              "name": "is",
-              "type": {
-                "text": "string"
-              },
-              "privacy": "public",
-              "static": true,
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "template",
-              "privacy": "private"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "href"
-            },
-            {
-              "name": "size"
-            }
-          ],
-          "superclass": {
-            "name": "HTMLElement"
-          },
-          "tagName": "praxis-isncsci-icon",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "PraxisIsncsciIcon",
-          "declaration": {
-            "name": "PraxisIsncsciIcon",
-            "module": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "declaration": {
-            "name": "PraxisIsncsciIcon",
-            "module": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts"
           }
         }
       ]
@@ -779,6 +751,249 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciExtraInputs/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciExtraInputs",
+          "declaration": {
+            "name": "PraxisIsncsciExtraInputs",
+            "module": "./praxisIsncsciExtraInputs"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciExtraInputs",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "template",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciExtraInputs",
+          "declaration": {
+            "name": "PraxisIsncsciExtraInputs",
+            "module": "src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciExtraInputs",
+            "module": "src/web/praxisIsncsciExtraInputs/praxisIsncsciExtraInputs.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciIcon",
+          "declaration": {
+            "name": "PraxisIsncsciIcon",
+            "module": "./praxisIsncsciIcon"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciIcon",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "template",
+              "privacy": "private"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "href"
+            },
+            {
+              "name": "size"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "praxis-isncsci-icon",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciIcon",
+          "declaration": {
+            "name": "PraxisIsncsciIcon",
+            "module": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciIcon",
+            "module": "src/web/praxisIsncsciIcon/praxisIsncsciIcon.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciInput/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciInput",
+          "declaration": {
+            "name": "PraxisIsncsciInput",
+            "module": "./praxisIsncsciInput"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/web/praxisIsncsciInput/praxisIsncsciInput.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PraxisIsncsciInput",
+          "members": [
+            {
+              "kind": "field",
+              "name": "is",
+              "privacy": "public",
+              "static": true,
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "template",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "buttons_onClick",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "button",
+                  "type": {
+                    "text": "HTMLButtonElement"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "innerHTML"
+            }
+          ],
+          "events": [
+            {
+              "name": "value_click",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "disabled"
+            },
+            {
+              "name": "sensory"
+            },
+            {
+              "name": "selected-value"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "PraxisIsncsciInput",
+          "declaration": {
+            "name": "PraxisIsncsciInput",
+            "module": "src/web/praxisIsncsciInput/praxisIsncsciInput.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "declaration": {
+            "name": "PraxisIsncsciInput",
+            "module": "src/web/praxisIsncsciInput/praxisIsncsciInput.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/web/praxisIsncsciInputLayout/index.ts",
       "declarations": [],
       "exports": [
@@ -818,11 +1033,29 @@
                 "text": "string"
               },
               "privacy": "private",
-              "default": "`\n    <style>\n    :host {\n      --grid-gap: 4px;\n      display: flex;\n      --input-layout-mobile-breakpoint: 600px;\n    }\n\n    [right-dermatomes] {\n      margin-right: var(--grid-gap);\n    }\n\n    /*\n    [right-dermatomes],\n    [left-dermatomes] {\n      filter: drop-shadow(0 2px 2px rgba(0, 0, 0, .3));\n    }\n    */\n\n    [diagram] {\n      background-color: #E2E2E2;\n      display: none;\n      flex-grow: 1;\n    }\n\n    @media (min-width: 22.5rem) {\n      [diagram] {\n        display: block;\n      }\n    }\n    </style>\n    <div right-dermatomes>\n      <praxis-isncsci-grid></praxis-isncsci-grid>\n    </div>\n    <div diagram>Body diagram</div>\n    <div left-dermatomes>\n      <praxis-isncsci-grid left></praxis-isncsci-grid>\n    </div>\n  `"
+              "default": "`\n    <style>\n      :host {\n        display: flex;\n        flex-direction: column;\n        gap: var(--space-6);\n      }\n\n      [grid-section] {\n        --grid-gap: var(--space-1);\n        display: flex;\n        justify-content: center;\n      }\n\n      [right-dermatomes],\n      [left-dermatomes] {\n        display: flex;\n        flex-direction: column;\n      }\n\n      [right-dermatomes] {\n        align-items: end;\n        margin-right: var(--grid-gap);\n      }\n\n      [left-dermatomes] {\n        align-items: start;\n        margin-left: var(--grid-gap);\n      }\n\n      [diagram] {\n        background-color: #E2E2E2;\n        display: none;\n        flex-grow: 1;\n      }\n\n      @media (min-width: 48rem) {\n        [diagram] {\n          display: block;\n        }\n      }\n    </style>\n    <div grid-section>\n      <div right-dermatomes>\n        <praxis-isncsci-grid></praxis-isncsci-grid>\n        <slot name=\"vac\"></slot>\n      </div>\n      <div diagram>Body diagram</div>\n      <div left-dermatomes>\n        <praxis-isncsci-grid left></praxis-isncsci-grid>\n        <slot name=\"dap\"></slot>\n      </div>\n    </div>\n    <praxis-isncsci-extra-inputs>\n      <slot name=\"non-key-muscles-header\" slot=\"non-key-muscles-header\"></slot>\n      <slot name=\"right-lowest-label\" slot=\"right-lowest-label\"></slot>\n      <slot name=\"right-lowest\" slot=\"right-lowest\"></slot>\n      <slot name=\"left-lowest-label\" slot=\"left-lowest-label\"></slot>\n      <slot name=\"left-lowest\" slot=\"left-lowest\"></slot>\n      <slot name=\"comments-label\" slot=\"comments-label\"></slot>\n      <slot name=\"comments\" slot=\"comments\"></slot>\n    </praxis-isncsci-extra-inputs>\n  `"
+            },
+            {
+              "kind": "method",
+              "name": "updateReadonly",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "readonly",
+                  "type": {
+                    "text": "boolean"
+                  }
+                }
+              ]
             },
             {
               "kind": "field",
               "name": "innerHTML"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "readonly"
             }
           ],
           "superclass": {

--- a/src/app/app.stories.ts
+++ b/src/app/app.stories.ts
@@ -68,13 +68,25 @@ window.customElements.define('web-app-story', webAppStory);
 
 const meta = {
   title: 'App/App',
+  args: {
+    readonly: false,
+    staticHeight: false,
+  },
+  argTypes: {
+    readonly: {control: 'boolean'},
+    staticHeight: {control: 'boolean'},
+  },
   render: (args) =>
     html`
       ${styles}
       <web-app-story>
-        <praxis-isncsci-web-app>
+        <praxis-isncsci-web-app ?static-height="${args.staticHeight}">
           ${unsafeHTML(
-            getAppLayoutTemplate(args.classificationStyle, 'assets/icons'),
+            getAppLayoutTemplate(
+              args.classificationStyle,
+              'assets/icons',
+              args.readonly,
+            ),
           )}
         </praxis-isncsci-web-app>
       </web-app-story>
@@ -84,5 +96,4 @@ const meta = {
 export default meta;
 type Story = StoryObj;
 
-// More on writing stories with args: https://storybook.js.org/docs/web-components/writing-stories/args
 export const Primary: Story = {parameters: {layout: 'fullscreen'}};

--- a/src/app/webApp.ts
+++ b/src/app/webApp.ts
@@ -32,6 +32,10 @@ export class PraxisIsncsciWebApp extends HTMLElement {
           flex-direction: column;
         }
 
+        :host([static-height]) ::slotted(praxis-isncsci-app-layout) {
+          height: auto;
+        }
+
         ::slotted(praxis-isncsci-app-layout) {
           height: 25rem;
           flex-grow: 1;

--- a/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
+++ b/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
@@ -220,9 +220,12 @@ const getClassificationTemplate = (iconsPath: string) => {
 export const getAppLayoutTemplate = (
   classificationStyle: '' | 'visible' | 'static',
   iconsPath: string,
+  readonly: boolean = false,
 ): string => {
   return `
-    <praxis-isncsci-app-layout classification-style="${classificationStyle}">
+    <praxis-isncsci-app-layout classification-style="${classificationStyle}" ${
+    readonly ? 'readonly' : ''
+  }>
       ${getAppBarTemplate(iconsPath)}
       ${getInputLayoutTemplate()}
       <praxis-isncsci-input slot="input-controls" disabled></praxis-isncsci-input>

--- a/src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.stories.ts
+++ b/src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.stories.ts
@@ -35,17 +35,23 @@ const meta = {
   title: 'WebComponents/PraxisIsncsciAppLayout',
   args: {
     classificationStyle: '',
+    readonly: false,
   },
   argTypes: {
     classificationStyle: {
       control: 'select',
       options: ['', 'visible', 'static'],
     },
+    readonly: {control: 'boolean'},
   },
   parameters: {layout: 'fullscreen'},
   render: (args) =>
     html`${styles}${unsafeHTML(
-      getAppLayoutTemplate(args.classificationStyle, 'assets/icons'),
+      getAppLayoutTemplate(
+        args.classificationStyle,
+        'assets/icons',
+        args.readonly,
+      ),
     )}`,
 } satisfies Meta;
 

--- a/src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts
+++ b/src/web/praxisIsncsciAppLayout/praxisIsncsciAppLayout.ts
@@ -6,6 +6,10 @@ export class PraxisIsncsciAppLayout extends HTMLElement {
     return 'praxis-isncsci-app-layout';
   }
 
+  public static get observedAttributes() {
+    return ['classification-style', 'readonly'];
+  }
+
   private template() {
     return `
       <style>
@@ -24,6 +28,14 @@ export class PraxisIsncsciAppLayout extends HTMLElement {
 
         :host([classification-style="static"]) :has(> [name=classification]) {
           position: static;
+        }
+
+        :host([classification-style="static"]) :has(> [name=input-layout]) {
+          height: auto;
+        }
+
+        :host([readonly]) :has(> [name=input-controls]) {
+          display: none;
         }
 
         :has(> [name=app-bar]) {
@@ -88,6 +100,34 @@ export class PraxisIsncsciAppLayout extends HTMLElement {
 
     const shadowRoot = this.attachShadow({mode: 'open'});
     shadowRoot.innerHTML = this.template();
+  }
+
+  private updateReadonly(readonly: boolean) {
+    const inputLayout = this.querySelector('[slot="input-layout"]');
+
+    if (!inputLayout) {
+      return;
+    }
+
+    if (readonly) {
+      inputLayout.setAttributeNode(document.createAttribute('readonly'));
+    } else {
+      inputLayout.removeAttribute('readonly');
+    }
+  }
+
+  public attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ) {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    if (name === 'readonly') {
+      this.updateReadonly(newValue !== null);
+    }
   }
 }
 

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
@@ -10,6 +10,10 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
     return 'praxis-isncsci-input-layout';
   }
 
+  public static get observedAttributes(): string[] {
+    return ['readonly'];
+  }
+
   private template: string = `
     <style>
       :host {
@@ -79,6 +83,33 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
 
     const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
     shadowRoot.innerHTML = this.template;
+  }
+
+  private updateReadonly(readonly: boolean) {
+    this.querySelectorAll('select, input, textarea').forEach((input) => {
+      const attributeName =
+        input instanceof HTMLSelectElement ? 'disabled' : 'readonly';
+
+      if (readonly) {
+        input.setAttributeNode(document.createAttribute(attributeName));
+      } else {
+        input.removeAttribute(attributeName);
+      }
+    });
+  }
+
+  public attributeChangedCallback(
+    name: string,
+    oldValue: string,
+    newValue: string,
+  ): void {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    if (name === 'readonly') {
+      this.updateReadonly(newValue !== null);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #160 

## Problem

## Problem

We need to add `readonly` attributes to the `praxis-isncsci-web-app` and the `praxis-isncsci-app-layout` components.

## Solution

**Web App**

- Sets the classification panel as `static` at the bottom of the interface

**App layout**

- Makes input controls `readonly` or `disabled` if they are select boxes
- Hides the input buttons

## Testing

- [x] 1. All [**Chromatic**](https://www.chromatic.com/build?appId=64f8d7c6e093108e99084a70&number=187) visual tests pass or can be approved

---

- [x] 2. Setting `praxis-isncsci-app-layout` as `readonly` disables all input controls and removes input buttons

<details>
  <summary>Test case</summary>

  1. Navigate to the `praxis-isncsci-app-layout` [**Storybook** story](https://64f8d7c6e093108e99084a70-pfcolsmzzw.chromatic.com/?path=/story/webcomponents-praxisisncsciapplayout--primary)
  2. Set the `readonly` control to `true`
  3. Confirm that:
     1. The input buttons are removed from the interface
     2. The VAC, DAP, and select boxes for lowest non-key muscles with motor function are disabled
     3. The comments text are gets disabled

<img alt="Readonly control set to true" width="400" src="https://github.com/praxis-isncsci/ui/assets/1294355/aa6b2b1d-566b-4cc2-b718-4bf1519c1e23" />


</details>

---

- [x] 3. Setting the `static-height` attribute in `praxis-isncsci-web-app` positions the **classification** panel as static at the bottom of the interface and prevents the layout section to have to resize to fit inside the view and the grid section to require a scrollbar.

<details>
  <summary>Test case</summary>

  1. Navigate to the `praxis-isncsci-web-app` [Primary **Storybook** story](https://64f8d7c6e093108e99084a70-pfcolsmzzw.chromatic.com/?path=/story/app-app--primary)
  2. Press the calculate button to force the **classification** panel to show
  3. Set the `staticHeight` control to `true`
  4. Confirm that:
     1. The app stops resizing to fit inside the viewport
     2. The **classification** dialog is position at the bottom of the screen as `static`

<img alt="staticHeight control set to true" width="496" src="https://github.com/praxis-isncsci/ui/assets/1294355/7f49d779-0b11-493a-ad1c-4e4f141f0af7" />

</details>
