### PR TITLE
Allow the `ExternalMessagePortProvider` to activate the `readonly` application state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/src/app/providers/appStore.provider.ts
+++ b/src/app/providers/appStore.provider.ts
@@ -39,6 +39,11 @@ export class AppStoreProvider implements IIsncsciAppStoreProvider {
     return Promise.resolve();
   }
 
+  public setReadonly(readonly: boolean): Promise<void> {
+    this.appStore.dispatch({type: Actions.SET_READONLY, payload: readonly});
+    return Promise.resolve();
+  }
+
   public setSelectedCells(cells: Cell[]): Promise<void> {
     this.appStore.dispatch({type: Actions.SET_SELECTED_CELLS, payload: cells});
     return Promise.resolve();

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.mdx
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.mdx
@@ -38,11 +38,14 @@ port1.onmessage = (e) => {
 const isncsciIframe = document.querySelector('iframe');
 
 isncsciIframe.addEventListener('load', () => {
-    isncsciIframe.contentWindow.postMessage({action: 'INITIALIZE_PORT'}, '*', [channel.port2]);
+  isncsciIframe.contentWindow.postMessage({action: 'INITIALIZE_PORT'}, '*', [
+    channel.port2,
+  ]);
 });
 ```
 
 You can pass exam data to the ISNCSCI form by sending a message with the `action` of `SET_EXAM_DATA` and the exam data.
+You can also pass the `readonly` flag to make the form readonly.
 
 ```typescript
 // Create exam data
@@ -58,13 +61,26 @@ let examData = {
   rightPinPrickC2: '1**',
   /* ... */
   rightPinPrickS4_5: '0',
-  leftMotorC5: { /* ... */ },
-  leftLightTouchC2: { /* ... */ },
-  leftPinPrickC2: { /* ... */ },
-}
+  leftMotorC5: {
+    /* ... */
+  },
+  leftLightTouchC2: {
+    /* ... */
+  },
+  leftPinPrickC2: {
+    /* ... */
+  },
+};
 
 // Send the exam data through the port
-port1.postMessage({action: 'SET_EXAM_DATA', examData});
+port1.postMessage({action: 'SET_EXAM_DATA', examData, readonly: false});
+```
+
+Making the component readonly is also possible without having to pass exam data.
+You can send a message with the `action` of `SET_READONLY` and the `readonly` flag.
+
+```typescript
+port1.postMessage({action: 'SET_READONLY', readonly: true, examData: null});
 ```
 
 > Reference: [MDN: Using window.postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
@@ -2,15 +2,17 @@ import {IExternalMessageProvider} from '@core/boundaries';
 import {ExamData} from '@core/domain';
 
 export class ExternalMessagePortProviderActions {
-  public static INITIALIZE_PORT: string = 'INITIALIZE_PORT';
-  public static SET_EXAM_DATA: string = 'SET_EXAM_DATA';
-  public static ON_EXAM_DATA: string = 'ON_EXAM_DATA';
-  public static ON_EXTERNAL_PORT: string = 'ON_EXTERNAL_PORT';
+  public static INITIALIZE_PORT = 'INITIALIZE_PORT';
+  public static ON_EXAM_DATA = 'ON_EXAM_DATA';
+  public static ON_EXTERNAL_PORT = 'ON_EXTERNAL_PORT';
+  public static ON_READONLY = 'ON_READONLY';
+  public static SET_EXAM_DATA = 'SET_EXAM_DATA';
+  public static SET_READONLY = 'SET_READONLY';
 }
 
 export class ExternalMessagePortProvider implements IExternalMessageProvider {
   private handlers: Array<
-    (actionType: string, examData: ExamData | null) => void
+    (actionType: string, examData: ExamData | null, readonly: boolean) => void
   > = [];
   private port: MessagePort | null = null;
 
@@ -26,37 +28,60 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     ) {
       this.port = e.ports[0] ?? null;
       this.port.onmessage = (e: MessageEvent) =>
-        this.onPortMessage(e.data.action, e.data.examData);
+        this.onPortMessage(e.data.action, e.data.examData, e.data.readonly);
       this.dispatch({
         examData: null,
+        readonly: false,
         type: ExternalMessagePortProviderActions.ON_EXTERNAL_PORT,
       });
     }
   }
 
-  private onPortMessage(action: string, examData: ExamData | null) {
+  private onPortMessage(
+    action: string,
+    examData: ExamData | null,
+    readonly: boolean,
+  ) {
     if (action === ExternalMessagePortProviderActions.SET_EXAM_DATA) {
       this.dispatch({
         examData,
         type: ExternalMessagePortProviderActions.ON_EXAM_DATA,
+        readonly,
+      });
+    }
+
+    if (action === ExternalMessagePortProviderActions.SET_READONLY) {
+      this.dispatch({
+        examData,
+        type: ExternalMessagePortProviderActions.ON_READONLY,
+        readonly,
       });
     }
   }
 
   public sendOutExamData(examData: ExamData) {
-    console.log(`sendExamDataThroughExternalChannel ${examData}`);
     this.port?.postMessage(examData);
   }
 
-  private dispatch(action: {type: string; examData: ExamData | null}) {
-    this.handlers.forEach((handler) => handler(action.type, action.examData));
+  private dispatch(action: {
+    type: string;
+    examData: ExamData | null;
+    readonly: boolean;
+  }) {
+    this.handlers.forEach((handler) =>
+      handler(action.type, action.examData, action.readonly),
+    );
   }
 
   /*
    * returns the unsubscribe function
    */
   public subscribe(
-    handler: (action: string, examData: ExamData | null) => void,
+    handler: (
+      action: string,
+      examData: ExamData | null,
+      readonly: boolean,
+    ) => void,
   ) {
     this.handlers.push(handler);
 

--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -10,11 +10,11 @@ class AppStore implements IDataStore<IAppState> {
     dap: null,
     gridModel: [],
     leftLowestNonKeyMuscleWithMotorFunction: null,
+    readonly: false,
     rightLowestNonKeyMuscleWithMotorFunction: null,
     selectedCells: [],
     selectedPoint: null,
     status: StatusCodes.NotInitialized,
-    updatedCells: [],
     totals: {
       asiaImpairmentScale: '',
       injuryComplete: '',
@@ -44,6 +44,7 @@ class AppStore implements IDataStore<IAppState> {
       touchTotal: '',
       upperMotorTotal: '',
     },
+    updatedCells: [],
     vac: null,
   };
 

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -8,6 +8,7 @@ export class Actions {
   public static SET_CELLS_VALUE = 'SET_CELLS_VALUE';
   public static SET_EXTRA_INPUTS = 'SET_EXTRA_INPUTS';
   public static SET_GRID_MODEL = 'SET_GRID_MODEL';
+  public static SET_READONLY = 'SET_READONLY';
   public static SET_SELECTED_CELLS = 'SET_SELECTED_CELLS';
   public static SET_TOTALS = 'SET_TOTALS';
   public static SET_VAC_DAP = 'SET_VAC_DAP';
@@ -55,6 +56,18 @@ const extraInputs = (
           action.payload.leftLowestNonKeyMuscleWithMotorFunction,
         comments: action.payload.comments,
       });
+    default:
+      return state;
+  }
+};
+
+const readonly = (
+  state: IAppState,
+  action: IActionWithPayload<boolean>,
+): IAppState => {
+  switch (action.type) {
+    case Actions.SET_READONLY:
+      return Object.assign({}, state, {readonly: action.payload});
     default:
       return state;
   }
@@ -132,6 +145,7 @@ export {
   activeCell,
   extraInputs,
   gridModel,
+  readonly,
   selectedCells,
   status,
   totals,
@@ -143,6 +157,7 @@ export default [
   activeCell,
   extraInputs,
   gridModel,
+  readonly,
   selectedCells,
   status,
   totals,

--- a/src/core/boundaries/iAppState.ts
+++ b/src/core/boundaries/iAppState.ts
@@ -14,6 +14,7 @@ export interface IAppState {
   gridModel: Array<Cell | null>[];
   leftLowestNonKeyMuscleWithMotorFunction: MotorLevel | null;
   rightLowestNonKeyMuscleWithMotorFunction: MotorLevel | null;
+  readonly: boolean;
   selectedPoint: string | null;
   selectedCells: Cell[];
   status: number;

--- a/src/core/boundaries/iIsncsciAppStore.provider.ts
+++ b/src/core/boundaries/iIsncsciAppStore.provider.ts
@@ -10,6 +10,7 @@ export interface IIsncsciAppStoreProvider {
     comments: string,
   ): Promise<void>;
   setGridModel(gridModel: Array<Cell | null>[]): Promise<void>;
+  setReadonly(readonly: boolean): Promise<void>;
   setSelectedCells(cells: Cell[]): Promise<void>;
   setTotals(totals: Totals): Promise<void>;
   setVacDap(

--- a/src/core/useCases/index.ts
+++ b/src/core/useCases/index.ts
@@ -2,3 +2,4 @@ export {calculateUseCase} from './calculate.useCase';
 export {initializeAppUseCase} from './initializeApp.useCase';
 export {loadExternalExamDataUseCase} from './loadExternalExamData.useCase';
 export {setCellsValueUseCase} from './setCellsValue.useCase';
+export {setReadonlyUseCase} from './setReadonly.useCase';

--- a/src/core/useCases/loadExternalExamData.useCase.ts
+++ b/src/core/useCases/loadExternalExamData.useCase.ts
@@ -9,6 +9,7 @@ import {
 export const loadExternalExamDataUseCase = async (
   appStoreProvider: IIsncsciAppStoreProvider,
   examData: ExamData,
+  readonly: boolean = false,
 ) => {
   // 1. Validate exam data
   const errors = validateExamData(examData);
@@ -25,5 +26,6 @@ export const loadExternalExamDataUseCase = async (
 
   // 4. Update state
   await appStoreProvider.setGridModel(gridModel);
+  await appStoreProvider.setReadonly(readonly);
   await appStoreProvider.setTotals(totals);
 };

--- a/src/core/useCases/setReadonly.spec.ts
+++ b/src/core/useCases/setReadonly.spec.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from '@jest/globals';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
+import {setReadonlyUseCase} from './setReadonly.useCase';
+
+describe('setReadonly.useCase.ts', () => {
+  describe('setReadonlyUseCase', () => {
+    it('calls the setReadonly method on the app store provider and passes the readonly flag', async () => {
+      // Arrange
+      const appStoreProvider = getAppStoreProviderMock();
+
+      // Act
+      setReadonlyUseCase(true, appStoreProvider);
+
+      // Assert
+      expect(appStoreProvider.setReadonly).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/src/core/useCases/setReadonly.useCase.ts
+++ b/src/core/useCases/setReadonly.useCase.ts
@@ -1,6 +1,6 @@
 import {IIsncsciAppStoreProvider} from '@core/boundaries';
 
-export const setVacDapUseCase = (
+export const setReadonlyUseCase = (
   readonly: boolean,
   appStoreProvider: IIsncsciAppStoreProvider,
 ) => {

--- a/src/core/useCases/setReadonly.useCase.ts
+++ b/src/core/useCases/setReadonly.useCase.ts
@@ -1,0 +1,8 @@
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+
+export const setVacDapUseCase = (
+  readonly: boolean,
+  appStoreProvider: IIsncsciAppStoreProvider,
+) => {
+  appStoreProvider.setReadonly(readonly);
+};

--- a/src/testHelpers/appStoreProviderMocks.ts
+++ b/src/testHelpers/appStoreProviderMocks.ts
@@ -7,6 +7,7 @@ export const getAppStoreProviderMock = (): IIsncsciAppStoreProvider => {
     setCellsValue: jest.fn(() => Promise.resolve()),
     setExtraInputs: jest.fn(() => Promise.resolve()),
     setGridModel: jest.fn(() => Promise.resolve()),
+    setReadonly: jest.fn(() => Promise.resolve()),
     setSelectedCells: jest.fn(() => Promise.resolve()),
     setTotals: jest.fn(() => Promise.resolve()),
     setVacDap: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Problem

Add a `readonly` flag to the application state to be flipped by a request coming from `ExternalMessagePortProvider`

When passing exam data, the a `readonly` flag can also be provided which would affect the application state and update the interfaces.

## Solution

- Added a use case to set the `readonly` state flag
- Allow the **external message provider** to pass a `readonly` value along with exam data
- Added a `setReadonly` handler to the **external message provider** to set the `readonly` value without requiring passing exam data
- Update the interface based on the chantes to the state

## Testing

- [x] Can pass exam data as `readonly`

<details>
  <summary>Test case</summary>

  1. Navigate to the [ExternalMessagePortProvider primary Storybook story]()
  2. Press the button `Load random exam as readonly`
  3. Confirm that:
     - Exam data passed by the  `ExternalMessagePortProvider` was set
     - The input buttons are removed
     - The select boxes for VAC, DAP, and lowest non-key muscles with motor function are `disabled`
     - The comments text area is readonly

</details>

---

- [x] Can pass exam data as editable

<details>
  <summary>Test case</summary>

  1. Navigate to the [ExternalMessagePortProvider primary Storybook story]()
  2. Press the button `Load random exam`
  3. Confirm that:
     - Exam data passed by the  `ExternalMessagePortProvider` was set
     - The input buttons are visible
     - The select boxes for VAC, DAP, and lowest non-key muscles with motor function are enabled
     - The comments text area is editable

</details>

---

- [x] Can switch back and forth from `readonly` to `editable` without reseting the exam data

<details>
  <summary>Test case</summary>

  1. Navigate to the [ExternalMessagePortProvider primary Storybook story]()
  2. Press the button `Load random exam`
  3. Confirm that:
     - Exam data passed by the  `ExternalMessagePortProvider` was set
     - The input buttons are visible
     - The select boxes for VAC, DAP, and lowest non-key muscles with motor function are enabled
     - The comments text area is editable
  4. Press the `Flip readonly flag` button
  5. Confirm the application is now read only
  6. Press the `Flip readonly flag` button again
  7. Confirm the application is back to editable

</details>
