### PR TITLE
[Cell input wire star values] Update star values when setting initial value

### DIFF
--- a/src/app/providers/appStore.provider.ts
+++ b/src/app/providers/appStore.provider.ts
@@ -10,10 +10,22 @@ export class AppStoreProvider implements IIsncsciAppStoreProvider {
     return Promise.resolve();
   }
 
-  public setCellsValue(cellsToUpdate: Cell[], value: string): Promise<void> {
+  public setCellsValue(
+    cellsToUpdate: Cell[],
+    value: string,
+    error: string | undefined,
+    reasonImpairmentNotDueToSci: string | undefined,
+    reasonImpairmentNotDueToSciSpecify: string | undefined,
+  ): Promise<void> {
     this.appStore.dispatch({
       type: Actions.SET_CELLS_VALUE,
-      payload: {cellsToUpdate, value},
+      payload: {
+        cellsToUpdate,
+        value,
+        error,
+        reasonImpairmentNotDueToSci,
+        reasonImpairmentNotDueToSciSpecify,
+      },
     });
     return Promise.resolve();
   }

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -129,12 +129,25 @@ const vacDap = (
 
 const values = (
   state: IAppState,
-  action: IActionWithPayload<{cellsToUpdate: Cell[]; value: string}>,
+  action: IActionWithPayload<{
+    cellsToUpdate: Cell[];
+    value: string;
+    error: string | undefined;
+    reasonImpairmentNotDueToSci: string | undefined;
+    reasonImpairmentNotDueToSciSpecify: string | undefined;
+  }>,
 ) => {
   switch (action.type) {
     case Actions.SET_CELLS_VALUE:
       const cellsToUpdate = action.payload.cellsToUpdate.slice();
-      cellsToUpdate.forEach((cell) => (cell.value = action.payload.value));
+      cellsToUpdate.forEach((cell) => {
+        cell.value = action.payload.value;
+        cell.error = action.payload.error;
+        cell.reasonImpairmentNotDueToSci =
+          action.payload.reasonImpairmentNotDueToSci;
+        cell.reasonImpairmentNotDueToSciSpecify =
+          action.payload.reasonImpairmentNotDueToSciSpecify;
+      });
       return Object.assign({}, state, {updatedCells: cellsToUpdate.slice()});
     default:
       return state;

--- a/src/core/boundaries/iIsncsciAppStore.provider.ts
+++ b/src/core/boundaries/iIsncsciAppStore.provider.ts
@@ -3,7 +3,13 @@ import {BinaryObservation} from '@core/domain';
 
 export interface IIsncsciAppStoreProvider {
   setActiveCell(cell: Cell | null): Promise<void>;
-  setCellsValue(cells: Cell[], value: string): Promise<void>;
+  setCellsValue(
+    cells: Cell[],
+    value: string,
+    error: string | undefined,
+    reasonImpairmentNotDueToSci: string | undefined,
+    reasonImpairmentNotDueToSciSpecify: string | undefined,
+  ): Promise<void>;
   setExtraInputs(
     rightLowestNonKeyMuscleWithMotorFunction: MotorLevel | null,
     leftLowestNonKeyMuscleWithMotorFunction: MotorLevel | null,

--- a/src/core/domain/cell.ts
+++ b/src/core/domain/cell.ts
@@ -4,4 +4,5 @@ export interface Cell {
   reasonImpairmentNotDueToSci: string | undefined;
   reasonImpairmentNotDueToSciSpecify: string | undefined;
   name: string;
-};
+  error: string | undefined;
+}

--- a/src/core/helpers/examData.helper.ts
+++ b/src/core/helpers/examData.helper.ts
@@ -96,6 +96,7 @@ const getCell = (name: string, dataKey: string, examData: ExamData): Cell => {
       ? examData[`${dataKey}ReasonImpairmentNotDueToSciSpecify`]
       : undefined,
     name,
+    error: undefined,
   };
 
   return cell;

--- a/src/core/helpers/regularExpressions.spec.ts
+++ b/src/core/helpers/regularExpressions.spec.ts
@@ -26,14 +26,19 @@ describe('regularExpressions', () => {
     [
       '0',
       '0*',
+      '0**',
       '1',
       '1*',
+      '1**',
       '2',
       '2*',
+      '2**',
       '3',
       '3*',
+      '3**',
       '4',
       '4*',
+      '4**',
       '5',
       'NT',
       'NT*',
@@ -44,7 +49,7 @@ describe('regularExpressions', () => {
       });
     });
 
-    ['0**', '6', '5*', 'a', 'b', '00', 'NT***'].forEach((v) => {
+    ['0***', '6', '5*', 'a', 'b', '00', 'NT***'].forEach((v) => {
       it(`should not match ${v}`, () => {
         expect(motorValueRegex.test(v)).toBeFalsy();
       });
@@ -52,16 +57,20 @@ describe('regularExpressions', () => {
   });
 
   describe('sensoryValue', () => {
-    ['0', '0*', '1', '1*', '2', 'NT', 'NT*', 'NT**'].forEach((v) => {
-      it(`should match ${v}`, () => {
-        expect(sensoryValueRegex.test(v)).toBeTruthy();
-      });
-    });
+    ['0', '0*', '0*', '1', '1*', '1*', '2', 'NT', 'NT*', 'NT**'].forEach(
+      (v) => {
+        it(`should match ${v}`, () => {
+          expect(sensoryValueRegex.test(v)).toBeTruthy();
+        });
+      },
+    );
 
-    ['3', '3*', '4', '4*', '5', 'a', 'b', '00', 'NT***'].forEach((v) => {
-      it(`should not match ${v}`, () => {
-        expect(sensoryValueRegex.test(v)).toBeFalsy();
-      });
-    });
+    ['1***', '3', '3*', '4', '4*', '5', 'a', 'b', '00', 'NT***'].forEach(
+      (v) => {
+        it(`should not match ${v}`, () => {
+          expect(sensoryValueRegex.test(v)).toBeFalsy();
+        });
+      },
+    );
   });
 });

--- a/src/core/helpers/regularExpressions.ts
+++ b/src/core/helpers/regularExpressions.ts
@@ -8,5 +8,5 @@ export const sensoryCellRegex =
   /^(right|left)-(light-touch|pin-prick)-(c[2-8]|t1[0-2]|t[1-9]|l[1-5]|s[1-3]|s4_5)$/;
 export const motorCellRegex = /^(right|left)-motor-(c|t|l|s)\d$/;
 export const cellLevelRegex = /((?!-)(c|t|l|s)(4_5|\d{1,2}))$/;
-export const motorValueRegex = /^([0-4]\*?|5|NT\*{0,2})$/;
-export const sensoryValueRegex = /^(0\*?|1\*?|2|NT\*{0,2})$/;
+export const motorValueRegex = /^([0-4]\*{0,2}|5|NT\*{0,2})$/;
+export const sensoryValueRegex = /^(0\*?|1\*{0,2}|2|NT\*{0,2})$/;

--- a/src/core/useCases/setActiveCell.useCase.spec.ts
+++ b/src/core/useCases/setActiveCell.useCase.spec.ts
@@ -13,6 +13,7 @@ const getEmptyCell = (name: string): Cell => {
     reasonImpairmentNotDueToSci: undefined,
     reasonImpairmentNotDueToSciSpecify: undefined,
     name,
+    error: undefined,
   };
 };
 

--- a/src/core/useCases/setCellsValue.useCase.spec.ts
+++ b/src/core/useCases/setCellsValue.useCase.spec.ts
@@ -61,6 +61,9 @@ describe('setCellValue.useCase.spec', () => {
       expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
         expectedCells,
         value,
+        undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -105,6 +108,9 @@ describe('setCellValue.useCase.spec', () => {
       expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
         expectedCells,
         value,
+        undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -161,6 +167,9 @@ describe('setCellValue.useCase.spec', () => {
       expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
         expectedCells,
         value,
+        undefined,
+        undefined,
+        undefined,
       );
     });
 
@@ -174,6 +183,8 @@ describe('setCellValue.useCase.spec', () => {
         findCell('right-motor-s1', gridModel),
       ];
       const propagateDown = false;
+      const expectedErrorMessage =
+        'Please indicate if the value should be considered normal or not normal.';
 
       // Act
       setCellsValueUseCase(
@@ -188,6 +199,63 @@ describe('setCellValue.useCase.spec', () => {
       expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
         selectedCells,
         value,
+        expectedErrorMessage,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('cells should not have any error message when the `value` does not have a star (*) flag', async () => {
+      // Arrange
+      const value = '1';
+      const selectedCells = [findCell('left-light-touch-c2', gridModel)];
+      const propagateDown = false;
+      let updatedCells: Cell[] = [];
+
+      // Act
+      await setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        selectedCells,
+        value,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should add an error message when `value` has a star (*) flag', async () => {
+      // Arrange
+      const value = '1*';
+      const selectedCells = [findCell('left-light-touch-c2', gridModel)];
+      const propagateDown = false;
+      let updatedCells: Cell[] = [];
+      const expectedErrorMessage =
+        'Please indicate if the value should be considered normal or not normal.';
+
+      // Act
+      await setCellsValueUseCase(
+        value,
+        selectedCells,
+        gridModel,
+        propagateDown,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        selectedCells,
+        value,
+        expectedErrorMessage,
+        undefined,
+        undefined,
       );
     });
   });

--- a/src/core/useCases/setCellsValue.useCase.ts
+++ b/src/core/useCases/setCellsValue.useCase.ts
@@ -11,14 +11,15 @@ import {
 
 /*
  * 1. Test value to make sure it is valid.
- * 2. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
- *  2.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
- *  2.3. Get the range of cells to update.
- *  2.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
- * 3. If there is more than one cell selected or `propagateDown` is ignored:
- *  3.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
- * 4. If there are no cells to update, we stop. Nothing gets updated.
- * 5. Call `appStoreProvider.setCellsValue` with the cells to update and the value.
+ * 2. Determine if an error message needs to be added for values flagged with a star.
+ * 3. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
+ *  3.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
+ *  3.3. Get the range of cells to update.
+ *  3.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
+ * 4. If there is more than one cell selected or `propagateDown` is ignored:
+ *  4.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
+ * 5. If there are no cells to update, we stop. Nothing gets updated.
+ * 6. Call `appStoreProvider.setCellsValue` with the cells to update and the value.
  */
 export const setCellsValueUseCase = async (
   value: string,
@@ -35,14 +36,19 @@ export const setCellsValueUseCase = async (
 
   const isSensoryValue = sensoryValueRegex.test(value);
 
-  // 2. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
+  // 2. Determine if an error message needs to be added for values flagged with a star.
+  const starErrorMessage = /\*/.test(value)
+    ? 'Please indicate if the value should be considered normal or not normal.'
+    : undefined;
+
+  // 3. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
   if (selectedCells.length === 1 && propagateDown) {
-    // 2.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
+    // 3.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
     if (sensoryCellRegex.test(selectedCells[0].name) && !isSensoryValue) {
       return;
     }
 
-    // 2.3. Get the range of cells to update.
+    // 3.3. Get the range of cells to update.
     const {motorRange, sensoryRange} = getCellRange(
       getCellPosition(selectedCells[0].name),
       null,
@@ -50,26 +56,38 @@ export const setCellsValueUseCase = async (
       true,
     );
 
-    // 2.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
-    appStoreProvider.setCellsValue(motorRange.concat(sensoryRange), value);
+    // 3.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
+    appStoreProvider.setCellsValue(
+      motorRange.concat(sensoryRange),
+      value,
+      starErrorMessage,
+      undefined,
+      undefined,
+    );
     return;
   }
 
-  // 3. If there is more than one cell selected or `propagateDown` is ignored:
+  // 4. If there is more than one cell selected or `propagateDown` is ignored:
   const cellsToUpdate: Cell[] = [];
 
-  // 3.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
+  // 4.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
   selectedCells.forEach((selectedCell) => {
     if (isSensoryValue || motorCellRegex.test(selectedCell.name)) {
       cellsToUpdate.push(selectedCell);
     }
   });
 
-  // 4. If there are no cells to update, we stop. Nothing gets updated.
+  // 5. If there are no cells to update, we stop. Nothing gets updated.
   if (cellsToUpdate.length === 0) {
     return;
   }
 
-  // 5. Call `appStoreProvider.setCellsValue` with the cells to update and the value.
-  appStoreProvider.setCellsValue(cellsToUpdate, value);
+  // 6. Call `appStoreProvider.setCellsValue` with the cells to update and the value.
+  appStoreProvider.setCellsValue(
+    cellsToUpdate,
+    value,
+    starErrorMessage,
+    undefined,
+    undefined,
+  );
 };


### PR DESCRIPTION
Closes #167 

## Problem

I want the details around _reason for impairment not due to SCI_ to be reset when setting a value. I want to create a separate use case to set `consider normal`, `reason`, `reason specify.

It is a bit unintuitive how the controls were finalized. We were not allowed to specify wether a value should be considered normal or not normal when initially setting it. This is a business decision I was not able to fight back. As a result, when initially setting the flag, the cell needs to be marked as having an input error. I think all this can be handled in `setCellsValueUseCase`.

## Solution

- Added `error: string | undefined` to the `Cell` interface
- Updated the providers to receive the error, reason for impairment not due to SCI, and comments when setting a value
- Updated the `setCellsValueUseCase` to reset the star related values or set the error message when a flag is being set

## Testing

- Make sure enough unit tests have been added to cover the changes
- Make sure the new logic makes sense
