### PR TITLE
[Cell input wire star values] Update elegible cells after setting a star input value

### DIFF
--- a/src/core/useCases/index.ts
+++ b/src/core/useCases/index.ts
@@ -3,3 +3,4 @@ export {initializeAppUseCase} from './initializeApp.useCase';
 export {loadExternalExamDataUseCase} from './loadExternalExamData.useCase';
 export {setCellsValueUseCase} from './setCellsValue.useCase';
 export {setReadonlyUseCase} from './setReadonly.useCase';
+export {setStarDetailsUseCase} from './setStarDetails.useCase';

--- a/src/core/useCases/setCellsValue.useCase.ts
+++ b/src/core/useCases/setCellsValue.useCase.ts
@@ -13,9 +13,10 @@ import {
  * 1. Test value to make sure it is valid.
  * 2. Determine if an error message needs to be added for values flagged with a star.
  * 3. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
- *  3.2. If the selected cell is a sensory cell and the value is not a motor value, we stop. Nothing gets updated.
- *  3.3. Get the range of cells to update.
- *  3.4. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
+ *  3.1. If the selected cell is a sensory cell and the value is a motor value, we stop. Nothing gets updated.
+ *  3.2. Get the range of cells to update.
+ *  3.3. Call `appStoreProvider.setCellsValue` with the range of cells and the value.
+ *  3.4. We stop.
  * 4. If there is more than one cell selected or `propagateDown` is ignored:
  *  4.1. Filter out the sensory cells if the value is a motor only value, add all cells to be updated otherwise.
  * 5. If there are no cells to update, we stop. Nothing gets updated.
@@ -64,6 +65,8 @@ export const setCellsValueUseCase = async (
       undefined,
       undefined,
     );
+
+    // 3.4. We stop.
     return;
   }
 

--- a/src/core/useCases/setStarDetails.useCase.spec.ts
+++ b/src/core/useCases/setStarDetails.useCase.spec.ts
@@ -1,0 +1,307 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+
+import {} from '@jest/globals';
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+import {Cell} from '@core/domain';
+import {bindExamDataToGridModel, findCell} from '@core/helpers';
+import {setStarDetailsUseCase} from './setStarDetails.useCase';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
+import {getCellRange, getEmptyExamData} from '@core/helpers/examData.helper';
+
+describe('setStarDetails.useCase.spec', () => {
+  describe('setStarDetailsUseCase', () => {
+    let appStoreProvider: IIsncsciAppStoreProvider;
+    let gridModel: Array<Cell | null>[] = [];
+
+    beforeEach(() => {
+      appStoreProvider = getAppStoreProviderMock();
+      gridModel = bindExamDataToGridModel(getEmptyExamData());
+      jest.resetModules();
+    });
+
+    it('throws an error when no cell is selected if the selected cells are not flagged with a star', async () => {
+      // Arrange
+      const selectedCells: Cell[] = [];
+      let errorMessage = '';
+      const expectedError = '`selectedCells` must contain at least one cell';
+
+      // Act
+      try {
+        await setStarDetailsUseCase(
+          null,
+          undefined,
+          undefined,
+          selectedCells,
+          gridModel,
+          false,
+          appStoreProvider,
+        );
+      } catch (error) {
+        errorMessage = (error as Error).message;
+      }
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).not.toHaveBeenCalled();
+      expect(errorMessage).toBe(expectedError);
+    });
+
+    it('throws an error when the selected cell is not flagged with a star', async () => {
+      // Arrange
+      const c2 = findCell('right-light-touch-c2', gridModel);
+      c2.value = '1';
+      c2.label = '1';
+      const selectedCells = [c2];
+      let errorMessage = '';
+      const expectedError =
+        'In order to indicate impairment not due to an SCI, the cells must be flagged with a star';
+
+      // Act
+      try {
+        await setStarDetailsUseCase(
+          null,
+          undefined,
+          undefined,
+          selectedCells,
+          gridModel,
+          false,
+          appStoreProvider,
+        );
+      } catch (error) {
+        errorMessage = (error as Error).message;
+      }
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).not.toHaveBeenCalled();
+      expect(errorMessage).toBe(expectedError);
+    });
+
+    it('provides a range of cells when only one cell is selected, `propagateDown` is set to `true` and the cells below the selected cell match in value', async () => {
+      // Arrange
+      const c2 = findCell('right-light-touch-c2', gridModel);
+      c2.value = '1*';
+      c2.label = '1*';
+      const c3 = findCell('right-light-touch-c3', gridModel);
+      c3.value = '1*';
+      c3.label = '1*';
+      const c4 = findCell('right-light-touch-c4', gridModel);
+      c4.value = '1*';
+      c4.label = '1*';
+      const c5 = findCell('right-light-touch-c5', gridModel);
+      c5.value = '1*';
+      c5.label = '1*';
+      const selectedCells = [c2];
+      const expectedRange = [c2, c3, c4, c5];
+
+      // Act
+      setStarDetailsUseCase(
+        false,
+        'a',
+        'b',
+        selectedCells,
+        gridModel,
+        true,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        expectedRange,
+        '1*',
+        undefined,
+        'a',
+        'b',
+      );
+    });
+
+    [
+      {
+        a: {
+          value: '1*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+        b: {
+          value: '2*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+      },
+      {
+        a: {
+          value: '1*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+        b: {
+          value: '1*',
+          error: 'error',
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+      },
+      {
+        a: {
+          value: '1*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+        b: {
+          value: '1*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: 'reason',
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+      },
+      {
+        a: {
+          value: '1*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: undefined,
+        },
+        b: {
+          value: '1*',
+          error: undefined,
+          reasonImpairmentNotDueToSci: undefined,
+          reasonImpairmentNotDueToSciSpecify: 'sepecify',
+        },
+      },
+    ].forEach(({a, b}) => {
+      it(`throws an error when the selected cells do not have the same value [${a.value}, ${b.value}], error [${a.error}, ${b.error}], reason [${a.reasonImpairmentNotDueToSci}, ${b.reasonImpairmentNotDueToSci}], and reason comments [${a.reasonImpairmentNotDueToSciSpecify}, ${b.reasonImpairmentNotDueToSciSpecify}]`, async () => {
+        // Arrange
+        const c2 = findCell('right-light-touch-c2', gridModel);
+        c2.value = a.value;
+        c2.error = a.error;
+        c2.reasonImpairmentNotDueToSci = a.reasonImpairmentNotDueToSci;
+        c2.reasonImpairmentNotDueToSciSpecify =
+          a.reasonImpairmentNotDueToSciSpecify;
+        const c3 = findCell('right-light-touch-c3', gridModel);
+        c3.value = b.value;
+        c3.error = b.error;
+        c3.reasonImpairmentNotDueToSci = b.reasonImpairmentNotDueToSci;
+        c3.reasonImpairmentNotDueToSciSpecify =
+          b.reasonImpairmentNotDueToSciSpecify;
+        const selectedCells = [c2, c3];
+        let errorMessage = '';
+        const expectedError =
+          'All cells must have the same value, considered normal or not normal, reasonImpairmentNotDueToSci, and reasonImpairmentNotDueToSciSpecify';
+
+        // Act
+        try {
+          await setStarDetailsUseCase(
+            null,
+            undefined,
+            undefined,
+            selectedCells,
+            gridModel,
+            false,
+            appStoreProvider,
+          );
+        } catch (error) {
+          errorMessage = (error as Error).message;
+        }
+
+        // Assert
+        expect(appStoreProvider.setCellsValue).not.toHaveBeenCalled();
+        expect(errorMessage).toBe(expectedError);
+      });
+    });
+
+    it('calls `appStoreProvider.setCellsValue` with the selected cells and the values when multiple cells are selected', async () => {
+      // Arrange
+      const c2 = findCell('right-light-touch-c2', gridModel);
+      c2.value = '1*';
+      c2.label = '1*';
+      const t3 = findCell('left-light-touch-t3', gridModel);
+      t3.value = '1*';
+      t3.label = '1*';
+      const c4 = findCell('right-pin-prick-c4', gridModel);
+      c4.value = '1*';
+      c4.label = '1*';
+      const c8 = findCell('left-motor-c8', gridModel);
+      c8.value = '1*';
+      c8.label = '1*';
+      const selectedCells = [c2, t3, c4, c8];
+
+      // Act
+      setStarDetailsUseCase(
+        false,
+        'a',
+        'b',
+        selectedCells,
+        gridModel,
+        true,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        selectedCells,
+        '1*',
+        undefined,
+        'a',
+        'b',
+      );
+    });
+
+    it('flags the value with double star when consider normal is set to true', async () => {
+      // Arrange
+      const c2 = findCell('right-light-touch-c2', gridModel);
+      c2.value = '1*';
+      c2.label = '1*';
+      const selectedCells = [c2];
+
+      // Act
+      setStarDetailsUseCase(
+        true,
+        'a',
+        'b',
+        selectedCells,
+        gridModel,
+        true,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        selectedCells,
+        '1**',
+        undefined,
+        'a',
+        'b',
+      );
+    });
+
+    it('sets sets an error message on the cells when consider normal is null', async () => {
+      // Arrange
+      const c2 = findCell('right-light-touch-c2', gridModel);
+      c2.value = '1*';
+      c2.label = '1*';
+      const selectedCells = [c2];
+
+      // Act
+      setStarDetailsUseCase(
+        null,
+        'a',
+        'b',
+        selectedCells,
+        gridModel,
+        true,
+        appStoreProvider,
+      );
+
+      // Assert
+      expect(appStoreProvider.setCellsValue).toHaveBeenCalledWith(
+        selectedCells,
+        '1*',
+        'Please indicate if the value should be considered normal or not normal.',
+        'a',
+        'b',
+      );
+    });
+  });
+});

--- a/src/core/useCases/setStarDetails.useCase.ts
+++ b/src/core/useCases/setStarDetails.useCase.ts
@@ -1,0 +1,118 @@
+import {IIsncsciAppStoreProvider} from '@core/boundaries';
+import {Cell} from '@core/domain';
+import {getCellColumn, getCellRow} from '@core/helpers';
+
+const cellsMatch = (a: Cell, b: Cell) => {
+  return (
+    a.value === b.value &&
+    a.error === b.error &&
+    a.reasonImpairmentNotDueToSci === b.reasonImpairmentNotDueToSci &&
+    a.reasonImpairmentNotDueToSciSpecify ===
+      b.reasonImpairmentNotDueToSciSpecify
+  );
+};
+
+const getDownPropagationCellRange = (
+  cell: Cell,
+  gridModel: Array<Cell | null>[],
+) => {
+  const column = getCellColumn(cell.name);
+  let continueDown = true;
+  let rowIndex = getCellRow(cell.name) + 1;
+  const range = [cell];
+
+  while (continueDown && rowIndex < gridModel.length) {
+    const nextCell = gridModel[rowIndex][column];
+
+    if (!nextCell) {
+      continue;
+    }
+
+    if (cellsMatch(nextCell, cell)) {
+      range.push(nextCell);
+    } else {
+      continueDown = false;
+    }
+
+    rowIndex++;
+  }
+
+  return range;
+};
+
+/*
+ * 1. Check that at least a cell was selected.
+ * 2. Check that for star flag.
+ * 3. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
+ *  3.1. Get the range of cells to update.
+ *  3.2. Call `appStoreProvider.setCellsValue` with the range of cells and the values.
+ *  3.3. We stop.
+ * 4. Check if all selected cells have the same value.
+ *  4.1. If there are mismatch, we throw an error.
+ * 5. Call `appStoreProvider.setCellsValue` with the selected cells and the values.
+ */
+export const setStarDetailsUseCase = (
+  considerNormal: boolean | null,
+  reason: string | undefined,
+  details: string | undefined,
+  selectedCells: Cell[],
+  gridModel: Array<Cell | null>[],
+  propagateDown: boolean,
+  appStoreProvider: IIsncsciAppStoreProvider,
+) => {
+  // 1. Check that at least a cell was selected.
+  if (selectedCells.length === 0) {
+    throw new Error('`selectedCells` must contain at least one cell');
+  }
+
+  // 2. Check that for star flag.
+  const referenceCell = selectedCells[0];
+
+  if (!/\*$/.test(referenceCell.value)) {
+    throw new Error(
+      'In order to indicate impairment not due to an SCI, the cells must be flagged with a star',
+    );
+  }
+
+  const value =
+    referenceCell.value.replace(/\*$/, '') + (considerNormal ? '**' : '*');
+  const error =
+    considerNormal === null
+      ? 'Please indicate if the value should be considered normal or not normal.'
+      : undefined;
+
+  // 3. Check if there is a single cell selected and `propagateDown` is set to `true` - we only propagate down if there is a single cell selected.
+  if (selectedCells.length === 1 && propagateDown) {
+    // 3.1. Get the range of cells to update.
+    const range = getDownPropagationCellRange(referenceCell, gridModel);
+
+    console.log(range);
+
+    // 3.2. Call `appStoreProvider.setCellsValue` with the range of cells and the values.
+    appStoreProvider.setCellsValue(range, value, error, reason, details);
+
+    // 3.3. We stop.
+    return;
+  }
+
+  // 4. We check if all selected cells have the same value.
+  const mismatch = selectedCells.find(
+    (selectedCell) => !cellsMatch(selectedCell, referenceCell),
+  );
+
+  if (mismatch) {
+    // 4.1. If there are mismatch, we throw an error.
+    throw new Error(
+      'All cells must have the same value, considered normal or not normal, reasonImpairmentNotDueToSci, and reasonImpairmentNotDueToSciSpecify',
+    );
+  }
+
+  // 5. Call `appStoreProvider.setCellsValue` with the selected cells and the values.
+  appStoreProvider.setCellsValue(
+    selectedCells.slice(),
+    value,
+    error,
+    reason,
+    details,
+  );
+};


### PR DESCRIPTION
Closes #169 

## Problem

Add a use case to handle setting values associated to cells flagged as having impairment not due to SCI for the following items:

- Consider normal or not normal
- Reason
- Reason details

**Cases**

- When multiple cells are selected, do not update if the values are not identical, throw an error
- If down propagation is on, update all cells below that have the same initial value and stop until you find one that does not match

## Solution

Added a use case to handle changes to the values associated to impairment not due to SCI.

## Testing

- Ensure unit tests cover the different aspects of the use case
- Ensure use case code makes sense
