### PR TITLE
Add error styles to cell

### DIFF
--- a/assets/css/_cell.css
+++ b/assets/css/_cell.css
@@ -1,3 +1,5 @@
 praxis-isncsci-input-layout {
+  --error: var(--light-soft-error);
   --highlighted-cell-border-color: var(--light-primary);
+  --on-error: var(--light-on-soft-error);
 }

--- a/assets/css/_tokens.css
+++ b/assets/css/_tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 19 Dec 2023 19:39:39 GMT
+ * Generated on Thu, 04 Jan 2024 22:24:17 GMT
  */
 
 :root {
@@ -81,20 +81,6 @@
   --font-line-height-900: 2.5rem;
   --font-line-height-1000: 3.25rem;
   --font-line-height-1100: 5.75rem;
-  --border-radius-1: .25rem;
-  --border-radius-2: .5rem;
-  --border-radius-3: .75rem;
-  --border-radius-4: 1rem;
-  --border-radius-5: 1.25rem;
-  --border-radius-6: 1.875rem;
-  --border-radius-00: 0rem;
-  --border-radius-05: .125rem;
-  --border-radius-full: 624.9375rem;
-  --border-width-1: .0625rem;
-  --border-width-2: .125rem;
-  --border-width-3: .1875rem;
-  --border-width-4: .25rem;
-  --border-width-5: .3125rem;
   --space-0: 0;
   --space-1: .25rem;
   --space-2: .5rem;
@@ -112,6 +98,20 @@
   --space-32: 8rem;
   --space-025: .0625rem;
   --space-05: .125rem;
+  --border-radius-1: .25rem;
+  --border-radius-2: .5rem;
+  --border-radius-3: .75rem;
+  --border-radius-4: 1rem;
+  --border-radius-5: 1.25rem;
+  --border-radius-6: 1.875rem;
+  --border-radius-00: 0rem;
+  --border-radius-05: .125rem;
+  --border-radius-full: 624.9375rem;
+  --border-width-1: .0625rem;
+  --border-width-2: .125rem;
+  --border-width-3: .1875rem;
+  --border-width-4: .25rem;
+  --border-width-5: .3125rem;
   --z-index-1: 100;
   --z-index-2: 400;
   --z-index-3: 510;
@@ -136,16 +136,16 @@
   --light-input-label-on-surface: #5e5e5e;
   --light-input-on-surface: #000000;
   --light-input-border: #ababab;
-  --light-shadow: #5f1877;
+  --light-foreground-primary: #000000;
   --light-foreground-caption-2: #5e5e5e;
   --light-foreground-caption: #000000;
-  --light-foreground-primary: #000000;
   --light-foreground-subdued: #5e5e5e;
   --light-body-diagram-bg: #ababab;
   --light-body-diagram-segment-bg: #f9f9f9;
   --light-body-diagram-key-sensory-point-bg: #848484;
   --light-body-diagram-foreground: #6a6a6a;
   --light-body-diagram-guide-bg: #848484;
+  --light-shadow: #5f1877;
   --light-acrylic: rgba(255, 255, 255, 0.4000);
   --light-primary: #a82ad1;
   --light-button-surface: rgba(255, 255, 255, 0.0000);
@@ -170,9 +170,9 @@
   --light-primary-container: #eed7f6;
   --light-secondary-container: #cfe5ea;
   --light-error-container: #f2dcd4;
+  --light-drop-down-border: #ababab;
   --light-text-area-border: #848484;
   --light-totals-label-foreground: #5e5e5e;
-  --light-drop-down-border: #ababab;
   --light-acrylic-medium: rgba(255, 255, 255, 0.6000);
   --light-acrylic-medium-high: rgba(255, 255, 255, 0.8000);
   --light-isncsci-input-button-surface: #ffffff;
@@ -185,6 +185,8 @@
   --light-isncsci-input-button-surface-selected: #a82ad1;
   --light-isncsci-input-button-on-surface-selected: #ffffff;
   --light-isncsci-input-button-surface-active: #f1c6ff;
+  --light-soft-error: #fef8f6;
+  --light-on-soft-errorr: #682710;
   --totals-cell-width: 3.25rem;
   --type-scale-caption-2-font-size: .625rem;
   --type-scale-caption-2-weight: 400;
@@ -275,9 +277,9 @@
   --classification-padding: 1rem;
   --classification-z-index: 100;
   --classification-total-padding-right: .5rem;
-  --classification-total-padding-left: .5rem;
-  --classification-total-padding-top: .25rem;
   --classification-total-padding-bottom: .25rem;
+  --classification-total-padding-top: .25rem;
+  --classification-total-padding-left: .5rem;
   --acrylic-background-blur: 1.5rem;
   --acrylic-backdrop-filter: blur(var(--acrylic-background-blur));
   --acrylic-inner-shadow: inset 0 0 0.125rem rgba(255, 255, 255, 0.4);

--- a/assets/tokens/primitives.value.tokens.json
+++ b/assets/tokens/primitives.value.tokens.json
@@ -317,68 +317,6 @@
       }
     }
   },
-  "border": {
-    "radius": {
-      "1": {
-        "type": "number",
-        "value": ".25rem"
-      },
-      "2": {
-        "type": "number",
-        "value": ".5rem"
-      },
-      "3": {
-        "type": "number",
-        "value": ".75rem"
-      },
-      "4": {
-        "type": "number",
-        "value": "1rem"
-      },
-      "5": {
-        "type": "number",
-        "value": "1.25rem"
-      },
-      "6": {
-        "type": "number",
-        "value": "1.875rem"
-      },
-      "00": {
-        "type": "number",
-        "value": "0rem"
-      },
-      "05": {
-        "type": "number",
-        "value": ".125rem"
-      },
-      "full": {
-        "type": "number",
-        "value": "624.9375rem"
-      }
-    },
-    "width": {
-      "1": {
-        "type": "number",
-        "value": ".0625rem"
-      },
-      "2": {
-        "type": "number",
-        "value": ".125rem"
-      },
-      "3": {
-        "type": "number",
-        "value": ".1875rem"
-      },
-      "4": {
-        "type": "number",
-        "value": ".25rem"
-      },
-      "5": {
-        "type": "number",
-        "value": ".3125rem"
-      }
-    }
-  },
   "space": {
     "0": {
       "type": "number",
@@ -447,6 +385,68 @@
     "05": {
       "type": "number",
       "value": ".125rem"
+    }
+  },
+  "border": {
+    "radius": {
+      "1": {
+        "type": "number",
+        "value": ".25rem"
+      },
+      "2": {
+        "type": "number",
+        "value": ".5rem"
+      },
+      "3": {
+        "type": "number",
+        "value": ".75rem"
+      },
+      "4": {
+        "type": "number",
+        "value": "1rem"
+      },
+      "5": {
+        "type": "number",
+        "value": "1.25rem"
+      },
+      "6": {
+        "type": "number",
+        "value": "1.875rem"
+      },
+      "00": {
+        "type": "number",
+        "value": "0rem"
+      },
+      "05": {
+        "type": "number",
+        "value": ".125rem"
+      },
+      "full": {
+        "type": "number",
+        "value": "624.9375rem"
+      }
+    },
+    "width": {
+      "1": {
+        "type": "number",
+        "value": ".0625rem"
+      },
+      "2": {
+        "type": "number",
+        "value": ".125rem"
+      },
+      "3": {
+        "type": "number",
+        "value": ".1875rem"
+      },
+      "4": {
+        "type": "number",
+        "value": ".25rem"
+      },
+      "5": {
+        "type": "number",
+        "value": ".3125rem"
+      }
     }
   },
   "z-index": {

--- a/assets/tokens/tokens.json
+++ b/assets/tokens/tokens.json
@@ -745,15 +745,15 @@
           }
         },
         "foreground": {
+          "primary": {
+            "$type": "color",
+            "$value": "{color.gray.1000}"
+          },
           "caption-2": {
             "$type": "color",
             "$value": "{color.gray.500}"
           },
           "caption": {
-            "$type": "color",
-            "$value": "{color.gray.1000}"
-          },
-          "primary": {
             "$type": "color",
             "$value": "{color.gray.1000}"
           },
@@ -792,27 +792,27 @@
           "$type": "color",
           "$value": "rgba(255, 255, 255, 0.4000)"
         },
+        "primary": {
+          "$type": "color",
+          "$value": "{color.lilac.400}"
+        },
         "button": {
           "surface": {
             "$type": "color",
             "$value": "rgba(255, 255, 255, 0.0000)"
           },
-          "on-surface": {
-            "$type": "color",
-            "$value": "{light.on-surface}"
-          },
           "surface-hover": {
             "$type": "color",
             "$value": "rgba(51, 4, 73, 0.0800)"
+          },
+          "on-surface": {
+            "$type": "color",
+            "$value": "{light.on-surface}"
           },
           "surface-active": {
             "$type": "color",
             "$value": "rgba(51, 4, 73, 0.1200)"
           }
-        },
-        "primary": {
-          "$type": "color",
-          "$value": "{color.lilac.400}"
         },
         "on-primary": {
           "$type": "color",
@@ -892,18 +892,18 @@
             "$value": "{light.input.border}"
           }
         },
+        "text-area": {
+          "border": {
+            "$type": "color",
+            "$value": "{color.gray.200}"
+          }
+        },
         "totals": {
           "label": {
             "foreground": {
               "$type": "color",
               "$value": "{light.foreground.subdued}"
             }
-          }
-        },
-        "text-area": {
-          "border": {
-            "$type": "color",
-            "$value": "{color.gray.200}"
           }
         },
         "acrylic-medium": {
@@ -957,6 +957,14 @@
               "$value": "{color.lilac.050}"
             }
           }
+        },
+        "soft-error": {
+          "$type": "color",
+          "$value": "{color.orange.015}"
+        },
+        "on-soft-errorr": {
+          "$type": "color",
+          "$value": "{color.orange.700}"
         }
       },
       "totals": {
@@ -1392,13 +1400,13 @@
           "$type": "number",
           "$value": "{space.1}"
         },
-        "padding-left": {
-          "$type": "number",
-          "$value": "{space.2}"
-        },
         "padding-top": {
           "$type": "number",
           "$value": "{space.1}"
+        },
+        "padding-left": {
+          "$type": "number",
+          "$value": "{space.2}"
         }
       },
       "acrylic": {

--- a/assets/tokens/tokens.value.tokens.json
+++ b/assets/tokens/tokens.value.tokens.json
@@ -54,20 +54,16 @@
         "value": "{color.gray.100}"
       }
     },
-    "shadow": {
-      "type": "color",
-      "value": "{color.lilac.700}"
-    },
     "foreground": {
+      "primary": {
+        "type": "color",
+        "value": "{color.gray.1000}"
+      },
       "caption-2": {
         "type": "color",
         "value": "{color.gray.500}"
       },
       "caption": {
-        "type": "color",
-        "value": "{color.gray.1000}"
-      },
-      "primary": {
         "type": "color",
         "value": "{color.gray.1000}"
       },
@@ -97,6 +93,10 @@
         "type": "color",
         "value": "{color.gray.200}"
       }
+    },
+    "shadow": {
+      "type": "color",
+      "value": "{color.lilac.700}"
     },
     "acrylic": {
       "type": "color",
@@ -196,6 +196,12 @@
       "type": "color",
       "value": "#f2dcd4"
     },
+    "drop-down": {
+      "border": {
+        "type": "color",
+        "value": "{light.input.border}"
+      }
+    },
     "text-area": {
       "border": {
         "type": "color",
@@ -208,12 +214,6 @@
           "type": "color",
           "value": "{light.foreground.subdued}"
         }
-      }
-    },
-    "drop-down": {
-      "border": {
-        "type": "color",
-        "value": "{light.input.border}"
       }
     },
     "acrylic-medium": {
@@ -267,6 +267,14 @@
           "value": "{color.lilac.050}"
         }
       }
+    },
+    "soft-error": {
+      "type": "color",
+      "value": "{color.orange.015}"
+    },
+    "on-soft-errorr": {
+      "type": "color",
+      "value": "{color.orange.700}"
     }
   },
   "totals": {
@@ -698,17 +706,17 @@
       "type": "number",
       "value": "{space.2}"
     },
-    "padding-left": {
+    "padding-bottom": {
       "type": "number",
-      "value": "{space.2}"
+      "value": "{space.1}"
     },
     "padding-top": {
       "type": "number",
       "value": "{space.1}"
     },
-    "padding-bottom": {
+    "padding-left": {
       "type": "number",
-      "value": "{space.1}"
+      "value": "{space.2}"
     }
   },
   "acrylic": {

--- a/src/web/praxisIsncsciCell/praxisIsncsciCell.mdx
+++ b/src/web/praxisIsncsciCell/praxisIsncsciCell.mdx
@@ -22,6 +22,7 @@ This will make it easy for the component or controller adding them to control th
 
 ### Attributes
 
+- `error` - boolean - if true, the error style is applied to the cell
 - `highlighted` - boolean - if true, the cell will be highlighted
 
 ### CSS Variables
@@ -37,11 +38,29 @@ This will make it easy for the component or controller adding them to control th
   <tbody>
     <tr>
       <td>
-        <code>--highlighted-cell-border-color</code>
+        <code>`--error`</code>
+      </td>
+      <td>Surface background color for a cell containing an error</td>
+      <td>
+        <code>`rgba(184, 69, 28, 0.1)`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--highlighted-cell-border-color`</code>
       </td>
       <td>&nbsp;</td>
       <td>
-        <code>orange</code>
+        <code>`orange`</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>`--on-error`</code>
+      </td>
+      <td>Foreground color to be used on a cell containing an error</td>
+      <td>
+        <code>`#682710`</code>
       </td>
     </tr>
   </tbody>
@@ -56,3 +75,7 @@ This will make it easy for the component or controller adding them to control th
 ### Highlighted
 
 <Canvas of={Stories.Highlighted} />
+
+### Error
+
+<Canvas of={Stories.Error} />

--- a/src/web/praxisIsncsciCell/praxisIsncsciCell.stories.ts
+++ b/src/web/praxisIsncsciCell/praxisIsncsciCell.stories.ts
@@ -15,12 +15,21 @@ type Story = StoryObj;
 
 export const Primary: Story = {
   render: () =>
-    html`<praxis-isncsci-cell style="width:45px">2</praxis-isncsci-cell>`,
+    html`<praxis-isncsci-cell style="width:45px; height:38px;"
+      >2</praxis-isncsci-cell
+    >`,
 };
 
 export const Highlighted: Story = {
   render: () =>
-    html`<praxis-isncsci-cell highlighted style="width:45px"
+    html`<praxis-isncsci-cell highlighted style="width:45px; height:38px;"
       >2</praxis-isncsci-cell
+    >`,
+};
+
+export const Error: Story = {
+  render: () =>
+    html`<praxis-isncsci-cell error style="width:45px; height:38px;"
+      >NT*</praxis-isncsci-cell
     >`,
 };

--- a/src/web/praxisIsncsciCell/praxisIsncsciCell.ts
+++ b/src/web/praxisIsncsciCell/praxisIsncsciCell.ts
@@ -15,21 +15,40 @@ export class PraxisIsncsciCell extends HTMLElement {
       :host {
         align-items: center;
         background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.8));
-        /*backdrop-filter: blur(150px);*/
         box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
         border: solid .5px rgba(0, 0, 0, .2);
         border-radius: 2px;
         display: flex;
+        flex-direction: column;
+        gap: 1px;
         justify-content: center;
         min-height: 32px;
         min-width: 32px;
-        transition: all .3s ease-in-out;
+        transition: transform .3s ease-in-out, border-color .3s ease-in-out;
         user-select: none;
       }
 
       :host([highlighted]) {
         transform: scale(1.1);
         border: solid 1px var(--highlighted-cell-border-color, orange);
+      }
+
+      :host([error]) {
+        background-color: var(--error, rgba(184, 69, 28, 0.1));
+        color: var(--on-error, #682710);
+      }
+
+      :host([error])::before {
+        content: '!';
+        font-size: 0.5rem;
+        font-weight: bold;
+        display: inline-block;
+        border: solid 0.03125rem var(--on-error, #682710);
+        width: 10px;
+        height: 10px;
+        line-height: 10px;
+        border-radius: 5px;
+        text-align: center;
       }
     </style>
     <slot></slot>


### PR DESCRIPTION
Related to #170 

## Problem

When using the `* star` flag, the consider normal field is not set by default. The interface needs to show which cells are missing the extra information. The cell needs styling to reflect this state.

## Solution

Added the `error` state to the cell. The cell now takes an `error` attribute. When marked with this attribute, the foreground and background color change and a `!` icon is used to call for the user's attention.

## Testing

- [x] 1. Styling is applied to the cell when the `error` attribute is present

<details>
  <summary>Test case</summary>

  1. Navigate to the [cell's error story](https://64f8d7c6e093108e99084a70-rjjqzpxonc.chromatic.com/?path=/story/webcomponents-input-cell--error)
  2. Confirm that the error styling is applied when the `error` attribute is present

</details>
