### PR TITLE
Added core/helpers to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "core/boundaries/esm/index.js",
     "core/domain/cjs/index.js",
     "core/domain/esm/index.js",
+    "core/helpers/cjs/index.js",
+    "core/helpers/esm/index.js",
     "core/useCases/cjs/index.js",
     "core/useCases/esm/index.js",
     "web/cjs/index.js",
@@ -87,7 +89,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "readme": "README.md",
-  "_id": "isncsci-ui@0.0.18"
+  "_id": "isncsci-ui@0.0.19"
 }


### PR DESCRIPTION
Closes #177 

## Problem

We get an exception when building `isncsci\web` on a project importing the library via **NPM**.

![image](https://github.com/praxis-isncsci/ui/assets/1294355/f8cb2e51-a6db-4e46-b8ae-e163e42d29fc)

## Solution

Add `core/helpers/cjs/index.js` and `core/helpers/esm/index.js` to the package's files.
