### PR TITLE
Add controllers to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "readme": "README.md",
-  "_id": "isncsci-ui@0.0.21"
+  "_id": "isncsci-ui@0.0.22"
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,6 +14,7 @@ const tsconfig = {
 };
 const libraryInputs = {
   'app/index': 'src/app/index.ts',
+  'app/controllers/index': 'src/app/controllers/index.ts',
   'app/providers/index': 'src/app/providers/index.ts',
   'app/providers/externalMessagePort.provider/index':
     'src/app/providers/externalMessagePort.provider/index.ts',

--- a/src/app/controllers/index.ts
+++ b/src/app/controllers/index.ts
@@ -1,0 +1,1 @@
+export {InputLayoutController} from './inputLayout.controller';

--- a/src/app/webApp.ts
+++ b/src/app/webApp.ts
@@ -16,8 +16,8 @@ import {
   ExternalMessagePortProvider,
   ExternalMessagePortProviderActions,
 } from '@app/providers';
-import {InputLayoutController} from '@app/controllers/inputLayout.controller';
-import {getEmptyExamData} from '@core/helpers/examData.helper';
+import {InputLayoutController} from '@app/controllers';
+import {getEmptyExamData} from '@core/helpers';
 import {ExamData} from '@core/domain';
 
 export class PraxisIsncsciWebApp extends HTMLElement {


### PR DESCRIPTION
## Problem

The modules under the `app/controllers` folder are not being exported therefore cannot be used outside `webApp`

## Solution

- Add `index.ts` to the `app/controllers` folder
- Add the new index file to the list of files to be included in the **Rollup** bundle
