### PR TITLE
[bug] Input buttons getting cut on pixel phone

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -18,7 +18,7 @@
       }
 
       praxis-isncsci-web-app {
-        height: 100vh;
+        height: 100dvh;
       }
     </style>
     <script>


### PR DESCRIPTION
Closes #190 

## Problem

On **Chrome** , when setting the height to `100vh`, the address bar height is not deducted from the height. The input buttons are getting cut at the bottom on the phone.

Here is a good description of the problem: https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile

## Solution

Use `100dvh` instead

## Testing

- [x] The app is the right height and the input buttons are not getting cut off on Chrome mobile

<details>
  <summary>Test case</summary>

  1. On **Chrome** on your **Android** phone, navigate to the [test site](https://brave-meadow-05543dc10-191.centralus.4.azurestaticapps.net/)
  2. Confirm that the app is the right height and the input buttons are not getting cut off

</details>
