### PR TITLE
[connect] Allow loading partial exams

### DIFF
--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
@@ -32,7 +32,7 @@ const storyInitializer = (getRandomExamData) => {
     let readonly = false;
 
     const getRandomEmptyValue = () => {
-      const emptyValues = [null, undefined, ''];
+      const emptyValues = [null, undefined, 'unknown', ''];
       return emptyValues[Math.floor(Math.random() * emptyValues.length)];
     };
 
@@ -63,17 +63,10 @@ const storyInitializer = (getRandomExamData) => {
       const examData = getRandomExamData();
       ['T12', 'L1', 'L2', 'L3', 'L4', 'L5', 'S1', 'S2', 'S3', 'S4_5'].forEach(
         (level) => {
-          [
-            'leftLightTouch',
-            'rightLightTouch',
-            'leftPinPrick',
-            'rightPinPrick',
-          ].forEach((side) => {
-            examData[`${side}${level}`] = getRandomEmptyValue();
-            examData[`${side}${level}ReasonImpairmentNotDueToSci`] = null;
-            examData[`${side}${level}ReasonImpairmentNotDueToSciSpecify`] =
-              null;
-          });
+          examData[`rightLightTouch${level}`] = getRandomEmptyValue();
+          examData[`leftLightTouch${level}`] = getRandomEmptyValue();
+          examData[`rightPinPrick${level}`] = getRandomEmptyValue();
+          examData[`leftPinPrick${level}`] = getRandomEmptyValue();
         },
       );
 

--- a/src/core/useCases/loadExternalExamData.useCase.ts
+++ b/src/core/useCases/loadExternalExamData.useCase.ts
@@ -11,20 +11,13 @@ export const loadExternalExamDataUseCase = async (
   examData: ExamData,
   readonly: boolean = false,
 ) => {
-  // 1. Validate exam data
-  const errors = validateExamData(examData);
-
-  if (errors.length > 0) {
-    throw new Error(`Invalid exam data: ${errors.join(', ')}`);
-  }
-
-  // 2. Bind exam data to a new grid model
+  // 1. Bind exam data to a new grid model
   const gridModel = bindExamDataToGridModel(examData);
 
-  // 3. Bind exam data to the totals
+  // 2. Bind exam data to the totals
   const totals = bindExamDataToTotals(examData);
 
-  // 4. Update state
+  // 3. Update state
   await appStoreProvider.setActiveCell(null, []);
   await appStoreProvider.setGridModel(gridModel);
   await appStoreProvider.setReadonly(readonly);


### PR DESCRIPTION
Closes #200 

## Problem

Systems which embed the calculator, like **Praxis Connect**, can store partial exams. Currently when passing partial exams via the `ExternalMessageProvider`, the application validates the exams and throws an exception if the exam is incomplete. We need to remove the validation rule.

### Initial report

Eduardo Echeverria, i am having some problems with the ISNCSCI Praxis Connect control, I understand that the ISNCSCI control will do some validation when receiving the data. However for Praxis Connect, we can save a partial form, for example if I am just recording one or some of the values (e.g. Light touch C1-C4) and save the form. The data will be recorded but when the form got reopened next time, the validation in the ISNSCSI control kicks in and it is giving a javascript error. Not sure if we can disable that in Praxis Connect and what is the impact. Please advise. Thx a lot

![MicrosoftTeams-image](https://github.com/praxis-isncsci/ui/assets/1294355/f9f154f3-671c-47ef-b6ae-3f8fff7a9da5)

![MicrosoftTeams-image (1)](https://github.com/praxis-isncsci/ui/assets/1294355/c8761d53-8d54-4dfa-9603-a143a43eeff1)

## Solution

- Fixed problem in `src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts` where data was being improperly passed
- Added unit test
- Removed validation to allow legacy data to pass through
