### PR TITLE
[Bug] Acrylic effect not working in Safari

### DIFF
--- a/assets/css/_classification.css
+++ b/assets/css/_classification.css
@@ -3,7 +3,8 @@ praxis-isncsci-classification {
   --background-color: var(--light-acrylic);
   --box-shadow: var(--acrylic-inner-shadow), var(--shadow-medium);
   --gap: var(--classification-gap);
-  --padding: var(--classification-padding);
+  --padding: var(--classification-padding) var(--classification-padding)
+    var(--classification-padding-bottom);
 }
 
 praxis-isncsci-classification-grid[slot='nli'],

--- a/assets/css/_tokens.css
+++ b/assets/css/_tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 23 Jan 2024 00:53:53 GMT
+ * Generated on Fri, 02 Feb 2024 21:05:03 GMT
  */
 
 :root {
@@ -131,14 +131,14 @@
   --breakpoint-xl: 90rem;
   --light-grid-caption-2-foreground: #5e5e5e;
   --light-grid-caption-foreground: #000000;
-  --light-grid-border-cell-total: #ababab;
   --light-grid-border-cell: #d4d4d4;
+  --light-grid-border-cell-total: #ababab;
   --light-input-label-on-surface: #5e5e5e;
   --light-input-on-surface: #000000;
   --light-input-border: #ababab;
-  --light-foreground-primary: #000000;
-  --light-foreground-caption-2: #5e5e5e;
   --light-foreground-caption: #000000;
+  --light-foreground-caption-2: #5e5e5e;
+  --light-foreground-primary: #000000;
   --light-foreground-subdued: #5e5e5e;
   --light-body-diagram-bg: #ababab;
   --light-body-diagram-segment-bg: #f9f9f9;
@@ -147,11 +147,11 @@
   --light-body-diagram-guide-bg: #848484;
   --light-shadow: #5f1877;
   --light-acrylic: rgba(255, 255, 255, 0.4000);
+  --light-primary: #a82ad1;
   --light-button-surface: rgba(255, 255, 255, 0.0000);
   --light-button-on-surface: #1b1b1b;
   --light-button-surface-hover: rgba(51, 4, 73, 0.0800);
   --light-button-surface-active: rgba(51, 4, 73, 0.1200);
-  --light-primary: #a82ad1;
   --light-on-primary: #ffffff;
   --light-error: #b8451c;
   --light-secondary: #007491;
@@ -170,8 +170,8 @@
   --light-primary-container: #eed7f6;
   --light-secondary-container: #cfe5ea;
   --light-error-container: #f2dcd4;
-  --light-text-area-border: #848484;
   --light-drop-down-border: #ababab;
+  --light-text-area-border: #848484;
   --light-totals-label-foreground: #5e5e5e;
   --light-isncsci-input-surface: rgba(255, 255, 255, 0.4000);
   --light-isncsci-input-button-surface: #ffffff;
@@ -280,8 +280,9 @@
   --classification-gap: 2.5rem;
   --classification-padding: 1rem;
   --classification-z-index: 100;
-  --classification-total-padding-right: .5rem;
+  --classification-padding-bottom: 2rem;
   --classification-total-padding-left: .5rem;
+  --classification-total-padding-right: .5rem;
   --classification-total-padding-bottom: .25rem;
   --classification-total-padding-top: .25rem;
   --acrylic-background-blur: 1.5rem;

--- a/assets/tokens/tokens.json
+++ b/assets/tokens/tokens.json
@@ -718,13 +718,13 @@
             }
           },
           "border": {
-            "cell-total": {
-              "$type": "color",
-              "$value": "{color.gray.100}"
-            },
             "cell": {
               "$type": "color",
               "$value": "{color.gray.050}"
+            },
+            "cell-total": {
+              "$type": "color",
+              "$value": "{color.gray.100}"
             }
           }
         },
@@ -745,7 +745,7 @@
           }
         },
         "foreground": {
-          "primary": {
+          "caption": {
             "$type": "color",
             "$value": "{color.gray.1000}"
           },
@@ -753,7 +753,7 @@
             "$type": "color",
             "$value": "{color.gray.500}"
           },
-          "caption": {
+          "primary": {
             "$type": "color",
             "$value": "{color.gray.1000}"
           },
@@ -792,6 +792,10 @@
           "$type": "color",
           "$value": "rgba(255, 255, 255, 0.4000)"
         },
+        "primary": {
+          "$type": "color",
+          "$value": "{color.lilac.400}"
+        },
         "button": {
           "surface": {
             "$type": "color",
@@ -809,10 +813,6 @@
             "$type": "color",
             "$value": "rgba(51, 4, 73, 0.1200)"
           }
-        },
-        "primary": {
-          "$type": "color",
-          "$value": "{color.lilac.400}"
         },
         "on-primary": {
           "$type": "color",
@@ -886,16 +886,16 @@
           "$type": "color",
           "$value": "#f2dcd4"
         },
-        "text-area": {
-          "border": {
-            "$type": "color",
-            "$value": "{color.gray.200}"
-          }
-        },
         "drop-down": {
           "border": {
             "$type": "color",
             "$value": "{light.input.border}"
+          }
+        },
+        "text-area": {
+          "border": {
+            "$type": "color",
+            "$value": "{color.gray.200}"
           }
         },
         "totals": {
@@ -1403,14 +1403,18 @@
         "z-index": {
           "$type": "number",
           "$value": "{z-index.1}"
+        },
+        "padding-bottom": {
+          "$type": "number",
+          "$value": "{space.8}"
         }
       },
       "classification-total": {
-        "padding-right": {
+        "padding-left": {
           "$type": "number",
           "$value": "{space.2}"
         },
-        "padding-left": {
+        "padding-right": {
           "$type": "number",
           "$value": "{space.2}"
         },

--- a/assets/tokens/tokens.value.tokens.json
+++ b/assets/tokens/tokens.value.tokens.json
@@ -28,13 +28,13 @@
         }
       },
       "border": {
-        "cell-total": {
-          "type": "color",
-          "value": "{color.gray.100}"
-        },
         "cell": {
           "type": "color",
           "value": "{color.gray.050}"
+        },
+        "cell-total": {
+          "type": "color",
+          "value": "{color.gray.100}"
         }
       }
     },
@@ -55,7 +55,7 @@
       }
     },
     "foreground": {
-      "primary": {
+      "caption": {
         "type": "color",
         "value": "{color.gray.1000}"
       },
@@ -63,7 +63,7 @@
         "type": "color",
         "value": "{color.gray.500}"
       },
-      "caption": {
+      "primary": {
         "type": "color",
         "value": "{color.gray.1000}"
       },
@@ -102,6 +102,10 @@
       "type": "color",
       "value": "rgba(255, 255, 255, 0.4000)"
     },
+    "primary": {
+      "type": "color",
+      "value": "{color.lilac.400}"
+    },
     "button": {
       "surface": {
         "type": "color",
@@ -119,10 +123,6 @@
         "type": "color",
         "value": "rgba(51, 4, 73, 0.1200)"
       }
-    },
-    "primary": {
-      "type": "color",
-      "value": "{color.lilac.400}"
     },
     "on-primary": {
       "type": "color",
@@ -196,16 +196,16 @@
       "type": "color",
       "value": "#f2dcd4"
     },
-    "text-area": {
-      "border": {
-        "type": "color",
-        "value": "{color.gray.200}"
-      }
-    },
     "drop-down": {
       "border": {
         "type": "color",
         "value": "{light.input.border}"
+      }
+    },
+    "text-area": {
+      "border": {
+        "type": "color",
+        "value": "{color.gray.200}"
       }
     },
     "totals": {
@@ -713,14 +713,18 @@
     "z-index": {
       "type": "number",
       "value": "{z-index.1}"
+    },
+    "padding-bottom": {
+      "type": "number",
+      "value": "{space.8}"
     }
   },
   "classification-total": {
-    "padding-right": {
+    "padding-left": {
       "type": "number",
       "value": "{space.2}"
     },
-    "padding-left": {
+    "padding-right": {
       "type": "number",
       "value": "{space.2}"
     },

--- a/src/web/praxisIsncsciClassification/praxisIsncsciClassification.ts
+++ b/src/web/praxisIsncsciClassification/praxisIsncsciClassification.ts
@@ -11,6 +11,7 @@ export class PraxisIsncsciClassification extends HTMLElement {
       <style>
         :host {
           backdrop-filter: var(--backdrop-filter, blur(1.5rem));
+          -webkit-backdrop-filter: var(--backdrop-filter, blur(1.5rem));
           background-color: var(--background-color, rgba(255, 255, 255, 0.4));
           box-shadow: var(--box-shadow, inset 0 0 1rem rgba(255, 255, 255, 0.4), 0 2px 4px rgba(95, 24, 119, 0.1), 0 1px 6px rgba(95, 24, 119, 0.05));
           display: flex;
@@ -22,7 +23,7 @@ export class PraxisIsncsciClassification extends HTMLElement {
           flex-wrap: wrap;
           gap: var(--gap, 2.5rem);
           justify-content: center;
-          padding: var(--padding, 1rem);
+          padding: var(--padding, 1rem 1rem 2rem 1rem);
         }
       </style>
       <slot name="header"></slot>


### PR DESCRIPTION
Closes #111 

## Problem

The **CSS** `blur` filter does not work in safari. Instead of getting an acrylic effect, we get an empty background for the classification dialog.

![Image](https://github.com/praxis-isncsci/ui/assets/1294355/f0655306-abb9-427e-8ed1-f540d0ec109d)

## Solution

- I added `-webkit-backdrop-filter: var(--backdrop-filter, blur(1.5rem));`, in addition to the line with just `backdrop-filter`

## Testing

- [x] the acrylic background is visible in **Safari**

<details>
  <summary>Test case</summary>

  1. In **Safari**, navigate to the [App **Storybook** story](https://64f8d7c6e093108e99084a70-zssmokaurz.chromatic.com/?path=/story/app-app--primary)
  2. Set the viewport size to `Large mobile`
      <img alt="Viewport dropdown" width="205" src="https://github.com/praxis-isncsci/ui/assets/1294355/004f0161-9fb3-43aa-9d6c-51ba78b3e145" />
  3. Press the `Calculate` button
  4. Confirm that the Classification dialog's background resembles an acrylic surface and blurs the contents behind it

</details>