### PR TITLE
Fix issue with incoming data

### DIFF
--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
@@ -22,11 +22,19 @@ const storyInitializer = (getRandomExamData) => {
   iframe.addEventListener('load', () => {
     const isncsciIframe = document.querySelector('iframe');
     const randomExamButton = document.querySelector('button[random-exam]');
+    const incompleteExamButton = document.querySelector(
+      'button[random-incomplete-exam]',
+    );
     const readonlyButton = document.querySelector('button[readonly]');
     const flipFlagButton = document.querySelector('button[flip-flag]');
     const channel = new MessageChannel();
     const port1 = channel.port1;
     let readonly = false;
+
+    const getRandomEmptyValue = () => {
+      const emptyValues = [null, undefined, ''];
+      return emptyValues[Math.floor(Math.random() * emptyValues.length)];
+    };
 
     // Listen for messages on port1
     port1.onmessage = (e) => {
@@ -48,6 +56,31 @@ const storyInitializer = (getRandomExamData) => {
         action: 'SET_EXAM_DATA',
         readonly,
         examData: getRandomExamData(),
+      });
+    });
+
+    incompleteExamButton?.addEventListener('click', () => {
+      const examData = getRandomExamData();
+      ['T12', 'L1', 'L2', 'L3', 'L4', 'L5', 'S1', 'S2', 'S3', 'S4_5'].forEach(
+        (level) => {
+          [
+            'leftLightTouch',
+            'rightLightTouch',
+            'leftPinPrick',
+            'rightPinPrick',
+          ].forEach((side) => {
+            examData[`${side}${level}`] = getRandomEmptyValue();
+            examData[`${side}${level}ReasonImpairmentNotDueToSci`] = null;
+            examData[`${side}${level}ReasonImpairmentNotDueToSciSpecify`] =
+              null;
+          });
+        },
+      );
+
+      port1.postMessage({
+        action: 'SET_EXAM_DATA',
+        readonly: false,
+        examData,
       });
     });
 
@@ -95,6 +128,7 @@ const template = () => html`
   ></iframe>
   <ul controls>
     <li><button random-exam>Load random exam</button></li>
+    <li><button random-incomplete-exam>Load random incomplete exam</button></li>
     <li><button readonly>Load random exam as readonly</button></li>
     <li><button flip-flag>Flip readonly flag</button></li>
   </ul>

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
@@ -28,7 +28,7 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     ) {
       this.port = e.ports[0] ?? null;
       this.port.onmessage = (e: MessageEvent) =>
-        this.onPortMessage(e.data.action, e.data.examData, e.data.readonly);
+        this.onPortMessage(e.data.action, e.data.readonly, e.data.examData);
       this.dispatch({
         examData: null,
         readonly: false,

--- a/src/core/useCases/loadExternalExamData.useCase.spec.ts
+++ b/src/core/useCases/loadExternalExamData.useCase.spec.ts
@@ -1,0 +1,44 @@
+import {
+  IExternalMessageProvider,
+  IIsncsciAppStoreProvider,
+} from '@core/boundaries';
+import {getEmptyExamData} from '@core/helpers';
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
+import {loadExternalExamDataUseCase} from './loadExternalExamData.useCase';
+
+describe('loadExternalExamData.useCase.ts', () => {
+  describe('loadExternalExamDataUseCase', () => {
+    let appStoreProvider: IIsncsciAppStoreProvider;
+    let externalMessageProvider: IExternalMessageProvider;
+
+    beforeEach(() => {
+      appStoreProvider = getAppStoreProviderMock();
+      externalMessageProvider = {
+        sendOutExamData: jest.fn(),
+      };
+      jest.resetModules();
+    });
+
+    it('sets the VAC and DAP values using the App Store Provider', async () => {
+      // Arrange
+      const readonly = false;
+      const vac = 'Yes';
+      const dap = 'No';
+      const examData = getEmptyExamData();
+      examData.voluntaryAnalContraction = vac;
+      examData.deepAnalPressure = dap;
+
+      // Act
+      await loadExternalExamDataUseCase(appStoreProvider, examData, readonly);
+
+      // Assert
+      expect(appStoreProvider.setActiveCell).toHaveBeenCalledWith(null, []);
+      expect(appStoreProvider.setGridModel).toHaveBeenCalled();
+      expect(appStoreProvider.setReadonly).toHaveBeenCalledWith(readonly);
+      expect(appStoreProvider.setTotals).toHaveBeenCalled();
+      expect(appStoreProvider.setVacDap).toHaveBeenCalledWith(vac, dap);
+      expect(appStoreProvider.setExtraInputs).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

There is an issue in `src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts` where the values from the incoming data are being incorrectly assigned when passing them to the event handlers.

## Solution

- Fixed the issue with the incoming data
- Added a button to test incoming incomplete exam data
- Added unit test

## Testing

- [x] Can load incomplete exam data

<details>
  <summary>Test case</summary>

  1. Navigate to the [external message port provider **Storybook** story](https://64f8d7c6e093108e99084a70-toznrbndwf.chromatic.com/?path=/story/app-app--primary)
  2. Press the `Load random incomplete exam` button
  3. Confirm that data is being loaded

</details>
