### PR TITLE
[bug] Missing calculated total

### DIFF
--- a/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
+++ b/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
@@ -229,7 +229,7 @@ const getClassificationTemplate = (iconsPath: string) => {
           <praxis-isncsci-classification-total data-total="left-light-touch-total"
             >&nbsp;</praxis-isncsci-classification-total
           >
-          <praxis-isncsci-classification-total data-total="touch-total"
+          <praxis-isncsci-classification-total data-total="light-touch-total"
             >&nbsp;</praxis-isncsci-classification-total
           >
           <div class="text-caption-2 row-header">Pin prick</div>


### PR DESCRIPTION
## Problem

The **light touch total** is blank after performing a calculation

## Solution

We missed to update `src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts` when whe renamed `touchTotal` to `lightTouchTotal` #201 
We just had to update the string in the file.

## Testing

- [x] 1. All totals are being populated

<details>
  <summary>Test case</summary>

  1. Navigate to the [App **Storybook** story]()
  2. Complete an exam
  3. Press the `Calculate` button
  4. Confirm that all totals are being populated

</details>