### PR TITLE
[connect] Add UNK as input option

### DIFF
--- a/src/app/controllers/keyPointsDiagram.controller.ts
+++ b/src/app/controllers/keyPointsDiagram.controller.ts
@@ -25,7 +25,7 @@ export class KeyPointDiagramController {
 
     return /\*\*$/.test(cell.value)
       ? '2'
-      : cell.value.replace(/((NT)?\**)$/, '');
+      : cell.value.replace(/((UNK|NT)?\**)$/, '');
   }
 
   private getKeyPointColor(lightTouch: Cell | null, pinPrick: Cell | null) {

--- a/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
+++ b/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
@@ -84,12 +84,15 @@ export const getIsncsciInputTemplate = (
   disabled: boolean,
   selectedValue: string | null,
   showStarInput: boolean,
+  showUnknown: boolean,
   sensory: boolean = false,
 ): string => {
   return `
     <praxis-isncsci-input slot="input-controls" ${disabled ? 'disabled' : ''} ${
     selectedValue ? `selected-value="${selectedValue}"` : ''
-  } ${showStarInput ? 'show-star-input' : ''} ${sensory ? 'sensory' : ''}>
+  } ${showStarInput ? 'show-star-input' : ''} ${
+    showUnknown ? 'show-unknown' : ''
+  } ${sensory ? 'sensory' : ''}>
       <label for="consider-normal" slot="consider-normal-label">Consider normal or not normal for classification:</label>
       <select name="consider-normal" id="consider-normal" slot="consider-normal">
         <option></option>
@@ -259,7 +262,7 @@ export const getAppLayoutTemplate = (
   }>
       ${getAppBarTemplate(iconsPath)}
       ${getInputLayoutTemplate()}
-      ${getIsncsciInputTemplate(true, null, false)}
+      ${getIsncsciInputTemplate(true, null, false, false)}
       ${getClassificationTemplate(iconsPath)}
     </praxis-isncsci-app-layout>
   `;

--- a/src/web/praxisIsncsciInput/praxisIsncsciInput.mdx
+++ b/src/web/praxisIsncsciInput/praxisIsncsciInput.mdx
@@ -28,6 +28,7 @@ For the button section we use a grid layout to easily align the buttons.
   Expects one of the following values: `['0', '0*', '1', '1*', '2', '2*', '3', '3*', '4', 4*', '5', 'NT', 'NT*', 'NT**']`.
 - `sensory` - `boolean` - Disables the motor only values when set to `true`.
 - `show-star-input` - `boolean` - Shows the extra input controls to collect the star related fields _consider normal_, _reason_, and _specify_, when set to `true`.
+- `show-unknown` - `boolean` - Shows the unknown button when set to `true`.
 
 ## Events
 

--- a/src/web/praxisIsncsciInput/praxisIsncsciInput.stories.ts
+++ b/src/web/praxisIsncsciInput/praxisIsncsciInput.stories.ts
@@ -44,11 +44,13 @@ export const Sensory: Story = {
     disabled: false,
     selectedValue: '',
     showStarInput: false,
+    showUnknown: false,
   },
   argTypes: {
     disabled: {control: 'boolean'},
     selectedValue: {control: 'select', options: sensoryValues},
     showStarInput: {control: 'boolean'},
+    showUnknown: {control: 'boolean'},
   },
   render: (args) =>
     html`${styles}${unsafeHTML(
@@ -56,6 +58,7 @@ export const Sensory: Story = {
         args.disabled,
         args.selectedValue,
         args.showStarInput,
+        args.showUnknown,
         true,
       ),
     )}`,
@@ -66,11 +69,13 @@ export const Motor: Story = {
     disabled: false,
     selectedValue: '',
     showStarInput: false,
+    showUnknown: false,
   },
   argTypes: {
     disabled: {control: 'boolean'},
     selectedValue: {control: 'select', options: motorValues},
     showStarInput: {control: 'boolean'},
+    showUnknown: {control: 'boolean'},
   },
   render: (args) =>
     html`${styles}${unsafeHTML(
@@ -78,6 +83,7 @@ export const Motor: Story = {
         args.disabled,
         args.selectedValue,
         args.showStarInput,
+        args.showUnknown,
         false,
       ),
     )}`,

--- a/src/web/praxisIsncsciInput/praxisIsncsciInput.ts
+++ b/src/web/praxisIsncsciInput/praxisIsncsciInput.ts
@@ -22,6 +22,14 @@ export class PraxisIsncsciInput extends HTMLElement {
           padding: var(--padding, 1rem);
         }
 
+        :host([show-unknown]) [unk] {
+          display: flex;
+        }
+
+        :host([show-unknown]) [buttons] > *:last-child {
+          grid-column: auto;
+        }
+
         /* Button styles */
 
         [buttons] {
@@ -186,6 +194,10 @@ export class PraxisIsncsciInput extends HTMLElement {
           width: 100%;
         }
 
+        [unk] {
+          display: none;
+        }
+
         @container (min-width: 48rem) {
           :host {
             border-radius: 0 0 var(--border-radius, 0.5rem) var(--border-radius, 0.5rem);
@@ -244,6 +256,9 @@ export class PraxisIsncsciInput extends HTMLElement {
         <div class="button-group">
           <button class="isncsci-input-button" value="5" motor-only>5</button>
         </div>
+        <div class="button-group" unk>
+          <button class="isncsci-input-button" value="UNK">UNK</button>
+        </div>
         <div class="button-group">
           <button class="isncsci-input-button left" value="NT">NT</button>
           <button class="isncsci-input-button right" value="NT*"><span>*</span></button>
@@ -299,7 +314,7 @@ export class PraxisIsncsciInput extends HTMLElement {
   private buttons_onClick(button: HTMLButtonElement) {
     const value = button.value;
 
-    if (!value || !/^([0-4]\*?|5|NT\*{0,2})$/.test(value)) {
+    if (!value || !/^([0-4]\*?|5|UNK|NT\*{0,2})$/.test(value)) {
       return;
     }
 


### PR DESCRIPTION
Closes #209 

## Problem

External systems that will be embedding the ISNCSCI Calculator need `UNK` as an option. This value is used to indicate a field has been left blank on purpose. Very common for systems collecting short versions of the form where only motor values are entered.

## Solution

- Add a `UNK` button that is hidden by default
- Add `UNK` as an input option
- Update key points diagram when `UNK` is present

<img width="345" alt="Screenshot 2024-03-01 at 2 28 40 PM" src="https://github.com/praxis-isncsci/ui/assets/1294355/4703666e-2b62-4847-a997-597eb1d9423c">

## Testing

- [x] 1. `[UNK]` is an input option

<details>
  <summary>Test case</summary>

  1. Navigate to the [PraxisIsncsciInput **Storybook** Sensory story](https://64f8d7c6e093108e99084a70-frgcdryoln.chromatic.com/?path=/story/webcomponents-isncsci-input--sensory)
  2. In the controls section, set `showUnknown` to `true`
      <img width="429" alt="Screenshot 2024-03-01 at 2 35 43 PM" src="https://github.com/praxis-isncsci/ui/assets/1294355/ca3fd4f5-724c-4683-8f10-81f5b0744923">
  4. Confirm there is a new `UNK` button between `5` and `NT`
      <img width="351" alt="Screenshot 2024-03-01 at 2 36 34 PM" src="https://github.com/praxis-isncsci/ui/assets/1294355/9ee1b6cf-099c-4ee9-9338-b148174d7180">
