### PR TITLE
[connect] Allow the classification to take place when UNK is present

### DIFF
--- a/src/app/app.stories.ts
+++ b/src/app/app.stories.ts
@@ -72,10 +72,12 @@ const meta = {
   args: {
     readonly: false,
     staticHeight: false,
+    showUnknown: false,
   },
   argTypes: {
     readonly: {control: 'boolean'},
     staticHeight: {control: 'boolean'},
+    showUnknown: {control: 'boolean'},
   },
   render: (args) =>
     html`
@@ -87,6 +89,7 @@ const meta = {
               args.classificationStyle,
               'assets/icons',
               args.readonly,
+              args.showUnknown,
             ),
           )}
         </praxis-isncsci-web-app>

--- a/src/core/domain/isncsciLevels.ts
+++ b/src/core/domain/isncsciLevels.ts
@@ -67,6 +67,7 @@ export type SensoryPointValue =
   | '1*'
   | '0**'
   | '1**'
+  | 'UNK'
   | 'NT'
   | 'NT*'
   | 'NT**';
@@ -113,6 +114,7 @@ export type MotorMuscleValue =
   | '2**'
   | '3**'
   | '4**'
+  | 'UNK'
   | 'NT'
   | 'NT*'
   | 'NT**';
@@ -125,6 +127,7 @@ export const ValidSensoryValues: SensoryPointValue[] = [
   '1*',
   '0**',
   '1**',
+  'UNK',
   'NT',
   'NT*',
   'NT**',
@@ -147,6 +150,7 @@ export const ValidMotorValues: MotorMuscleValue[] = [
   '2**',
   '3**',
   '4**',
+  'UNK',
   'NT',
   'NT*',
   'NT**',

--- a/src/core/helpers/examData.helper.ts
+++ b/src/core/helpers/examData.helper.ts
@@ -805,3 +805,18 @@ export const getEmptyExamData = (): ExamData => {
     upperMotorTotal: '',
   };
 };
+
+export const cloneExamData = (
+  examData: ExamData,
+  convertUnkToNt: boolean = false,
+): ExamData => {
+  const clonedExamData = {...examData};
+
+  Object.keys(clonedExamData).forEach((key) => {
+    if (convertUnkToNt && /UNK/i.test(clonedExamData[key])) {
+      clonedExamData[key] = 'NT';
+    }
+  });
+
+  return clonedExamData;
+};

--- a/src/core/helpers/regularExpressions.spec.ts
+++ b/src/core/helpers/regularExpressions.spec.ts
@@ -40,6 +40,7 @@ describe('regularExpressions', () => {
       '4*',
       '4**',
       '5',
+      'UNK',
       'NT',
       'NT*',
       'NT**',
@@ -57,7 +58,7 @@ describe('regularExpressions', () => {
   });
 
   describe('sensoryValue', () => {
-    ['0', '0*', '0*', '1', '1*', '1*', '2', 'NT', 'NT*', 'NT**'].forEach(
+    ['0', '0*', '0*', '1', '1*', '1*', '2', 'UNK', 'NT', 'NT*', 'NT**'].forEach(
       (v) => {
         it(`should match ${v}`, () => {
           expect(sensoryValueRegex.test(v)).toBeTruthy();

--- a/src/core/helpers/regularExpressions.spec.ts
+++ b/src/core/helpers/regularExpressions.spec.ts
@@ -23,7 +23,7 @@ describe('regularExpressions', () => {
   });
 
   describe('motorValue', () => {
-    [
+    it.each([
       '0',
       '0*',
       '0**',
@@ -44,34 +44,36 @@ describe('regularExpressions', () => {
       'NT',
       'NT*',
       'NT**',
-    ].forEach((v) => {
-      it(`should match ${v}`, () => {
-        expect(motorValueRegex.test(v)).toBeTruthy();
-      });
-    });
+    ])('`motorValueRegex` should match %i', (v) =>
+      expect(motorValueRegex.test(v)).toBeTruthy(),
+    );
 
-    ['0***', '6', '5*', 'a', 'b', '00', 'NT***'].forEach((v) => {
-      it(`should not match ${v}`, () => {
-        expect(motorValueRegex.test(v)).toBeFalsy();
-      });
-    });
+    it.each(['0***', '6', '5*', 'a', 'b', '00', 'NT***'])(
+      '`motorValueRegex` should not match %i',
+      (v) => expect(motorValueRegex.test(v)).toBeFalsy(),
+    );
   });
 
   describe('sensoryValue', () => {
-    ['0', '0*', '0*', '1', '1*', '1*', '2', 'UNK', 'NT', 'NT*', 'NT**'].forEach(
-      (v) => {
-        it(`should match ${v}`, () => {
-          expect(sensoryValueRegex.test(v)).toBeTruthy();
-        });
-      },
+    it.each([
+      '0',
+      '0*',
+      '0*',
+      '1',
+      '1*',
+      '1*',
+      '2',
+      'UNK',
+      'NT',
+      'NT*',
+      'NT**',
+    ])('`sensoryValueRegex` should match %i', (v) =>
+      expect(sensoryValueRegex.test(v)).toBeTruthy(),
     );
 
-    ['1***', '3', '3*', '4', '4*', '5', 'a', 'b', '00', 'NT***'].forEach(
-      (v) => {
-        it(`should not match ${v}`, () => {
-          expect(sensoryValueRegex.test(v)).toBeFalsy();
-        });
-      },
+    it.each(['1***', '3', '3*', '4', '4*', '5', 'a', 'b', '00', 'NT***'])(
+      '`sensoryValueRegex` should not match %i',
+      (v) => expect(sensoryValueRegex.test(v)).toBeFalsy(),
     );
   });
 });

--- a/src/core/helpers/regularExpressions.ts
+++ b/src/core/helpers/regularExpressions.ts
@@ -8,6 +8,6 @@ export const sensoryCellRegex =
   /^(right|left)-(light-touch|pin-prick)-(c[2-8]|t1[0-2]|t[1-9]|l[1-5]|s[1-3]|s4_5)$/;
 export const motorCellRegex = /^(right|left)-motor-(c|t|l|s)\d$/;
 export const cellLevelRegex = /((?!-)(c|t|l|s)(4_5|\d{1,2}))$/;
-export const motorValueRegex = /^([0-4]\*{0,2}|5|NT\*{0,2})$/;
-export const sensoryValueRegex = /^(0\*?|1\*{0,2}|2|NT\*{0,2})$/;
+export const motorValueRegex = /^([0-4]\*{0,2}|5|UNK|NT\*{0,2})$/;
+export const sensoryValueRegex = /^(0\*?|1\*{0,2}|2|UNK|NT\*{0,2})$/;
 export const levelNameRegex = /((?!-)(c|t|l|s)1?[0-9]$)|((?!-)s4_5)/;

--- a/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
+++ b/src/web/praxisIsncsciAppLayout/appLayoutTemplate.ts
@@ -255,6 +255,7 @@ export const getAppLayoutTemplate = (
   classificationStyle: '' | 'visible' | 'static',
   iconsPath: string,
   readonly: boolean = false,
+  showUnknown: boolean = false,
 ): string => {
   return `
     <praxis-isncsci-app-layout classification-style="${classificationStyle}" ${
@@ -262,7 +263,7 @@ export const getAppLayoutTemplate = (
   }>
       ${getAppBarTemplate(iconsPath)}
       ${getInputLayoutTemplate()}
-      ${getIsncsciInputTemplate(true, null, false, false)}
+      ${getIsncsciInputTemplate(true, null, false, showUnknown)}
       ${getClassificationTemplate(iconsPath)}
     </praxis-isncsci-app-layout>
   `;


### PR DESCRIPTION
Closes #211 

## Problem

Third party applications that embed this application, like **Praxis Connect**, allow the collection of `UNK` as value. This value is used in cases where cells are left empty on purpose in a database. This is a very common behaviour for systems that allow the collection of short version ISNCSCI where only motor values are collected.

## Solution

- We are allowing the collection of unknown values. They need to be treated as NT when classifying an exam.
- We allow passing a flag to the **app layout template** to show or hide the `UNK` in the inputs.

## Testing

- [x] 1. Can calculate an exam with `UNK` values

<details>
  <summary>Test case</summary>

  1. Navigate to the [App primary Storybook story with the `show unknown` flag turned set to `true`](https://64f8d7c6e093108e99084a70-rzygihasdt.chromatic.com/?path=/story/app-app--primary&args=showUnknown:!true)
  2. Enter all `UNK` values
  3. Set the VAC and DAP to any value
  4. Press the **calculate** button
  5. Confirm the system produces a classification and all `UNK` values are treated as `NT`

</details>
