### PR TITLE
[connect] Report the form completion state on change or classification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "readme": "README.md",
-  "_id": "isncsci-ui@1.0.1"
+  "_id": "isncsci-ui@1.0.2"
 }

--- a/src/core/domain/examData.ts
+++ b/src/core/domain/examData.ts
@@ -7,6 +7,7 @@ export type ExamData = {
   voluntaryAnalContraction: BinaryObservation | null;
   rightLowestNonKeyMuscleWithMotorFunction: MotorLevel | null;
   leftLowestNonKeyMuscleWithMotorFunction: MotorLevel | null;
+  isComplete: boolean;
 
   /* Right Sensory */
   rightLightTouchC2: string;

--- a/src/core/helpers/examData.helper.ts
+++ b/src/core/helpers/examData.helper.ts
@@ -376,6 +376,7 @@ export const getEmptyExamData = (): ExamData => {
     voluntaryAnalContraction: null,
     rightLowestNonKeyMuscleWithMotorFunction: null,
     leftLowestNonKeyMuscleWithMotorFunction: null,
+    isComplete: false,
     /* Right Sensory */
     rightLightTouchC2: '',
     rightLightTouchC2ReasonImpairmentNotDueToSci: null,

--- a/src/core/useCases/calculate.useCase.ts
+++ b/src/core/useCases/calculate.useCase.ts
@@ -19,8 +19,9 @@ import {cloneExamData} from '@core/helpers/examData.helper';
  * 3. Convert any `UNK` values to `NT` before performing the calculation
  * 4. Calculate totals
  * 5. Bind totals to exam data
- * 6. Update state
- * 7. Update external listeners
+ * 6. Mark exam data as complete
+ * 7. Update state
+ * 8. Update external listeners
  */
 export const calculateUseCase = (
   gridModel: Array<Cell | null>[],
@@ -64,10 +65,13 @@ export const calculateUseCase = (
       examData[key] = totals[key];
     });
 
-    // 6. Update state
+    // 6. Mark exam data as complete
+    examData.isComplete = true;
+
+    // 7. Update state
     appStoreProvider.setTotals(totals);
 
-    // 7. Update external listeners
+    // 8. Update external listeners
     externalMessageProvider.sendOutExamData(examData);
   });
 };


### PR DESCRIPTION
Closes #214 

## Problem

As part of the payload being passed to a containing system via the external message provider we need to pass a boolean to indicate if a form is complete.

A complete form is a form with all values, including VAC and DAP, as well as classfication.

## Solution

- Added the property `isComplete` to the `examData` object
- Set the flag to `true` when a form is complete and a classification has been produced

## Test

- [x] 1. `isComplete` is set to `true` when a classification has been produced and the data has been set out via `external message provider`

<details>
  <summary>Test case</summary>

  1. Navigate to [external message provider **Storybook** story]()
  2. Press the **Load random exam** button
  3. Press the **Calculate** button
  4. Open the developer panel
  5. Confirm that the classified exam data has been sent out by looking at the data on the console
  6. Confirm that the `isComplete` flag is set to true

      <img width="746" alt="iscomplete" src="https://github.com/praxis-isncsci/ui/assets/1294355/e6d1bd72-6529-4f5a-8f62-56804731adcc">

</details>