### PR TITLE
Praxis Connect ISNCSCI Control - Input values at all levels but leave VAC and DAP blank - once form is saved, all values are missing when form is reopened

### DIFF
--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
@@ -61,6 +61,7 @@ const storyInitializer = (getRandomExamData) => {
 
     incompleteExamButton?.addEventListener('click', () => {
       const examData = getRandomExamData();
+      examData.voluntaryAnalContraction = getRandomEmptyValue();
       ['T12', 'L1', 'L2', 'L3', 'L4', 'L5', 'S1', 'S2', 'S3', 'S4_5'].forEach(
         (level) => {
           [

--- a/src/core/domain/binaryObservation.ts
+++ b/src/core/domain/binaryObservation.ts
@@ -1,1 +1,6 @@
 export type BinaryObservation = 'Yes' | 'No' | 'NT';
+export const ValidBinaryObservationValues: BinaryObservation[] = [
+  'Yes',
+  'No',
+  'NT',
+];

--- a/src/core/helpers/examData.helper.ts
+++ b/src/core/helpers/examData.helper.ts
@@ -14,6 +14,7 @@ import {
   validCellNameRegex,
 } from './regularExpressions';
 import {BinaryObservation} from '@core/domain';
+import {ValidBinaryObservationValues} from '@core/domain/binaryObservation';
 
 const validateValue = (
   dataKey: string,
@@ -48,11 +49,17 @@ const validateValue = (
 export const validateExamData = (examData: ExamData) => {
   const errors: string[] = [];
 
-  if (!examData.voluntaryAnalContraction) {
+  if (
+    examData.voluntaryAnalContraction &&
+    !ValidBinaryObservationValues.includes(examData.voluntaryAnalContraction)
+  ) {
     errors.push('Voluntary Anal Contraction is not set');
   }
 
-  if (!examData.deepAnalPressure) {
+  if (
+    examData.deepAnalPressure &&
+    !ValidBinaryObservationValues.includes(examData.deepAnalPressure)
+  ) {
     errors.push('Deep Anal Pressure is not set');
   }
 


### PR DESCRIPTION
Closes #217 

## Problem

Incoming exam data missing `VAC` and `DAP` fields is not passing validation. The system throws an exception and no data is being loaded. 

## Solution

Only attempt to validate the incoming `VAC` and `DAP` data if a value is present. Ignore all empty strings, `null`, and `undefined` values.

## Testing

- [x] 1. Can load incomplete form data which is missing `VAC` or `DAP`

<details>
  <summary>Test case</summary>

  1. Navigate to the **External message port provider Storybook story**
  2. Press the **Load random incomplete exam** button
  3. Confirm that an incomplete form is loaded and `VAC` has no value
</details>

---
