### PR TITLE
[Connect] Make classification style optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "readme": "README.md",
-  "_id": "isncsci-ui@1.0.2"
+  "_id": "isncsci-ui@1.0.3"
 }

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.spec.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.spec.ts
@@ -1,0 +1,148 @@
+import {describe, expect, it, jest} from '@jest/globals';
+import {
+  ExternalMessagePortProvider,
+  ExternalMessagePortProviderActions,
+} from './externalMessagePort.provider';
+import {ExamData} from '@core/domain';
+import {getEmptyExamData} from '@core/helpers';
+
+describe('ExternalMessagePortProvider', () => {
+  it('should initialize the port', async () => {
+    let windowEventHandler: (event) => void = () => {};
+    const handler = jest.fn();
+    const port = {
+      postMessage: jest.fn(),
+      onmessage: jest.fn(),
+    };
+
+    const window = {
+      addEventListener: (_, handler) => (windowEventHandler = handler),
+    };
+
+    const externalMessagePortProvider = new ExternalMessagePortProvider(
+      window as Window,
+    );
+    externalMessagePortProvider.subscribeToOnExternalPort(handler);
+
+    windowEventHandler.call(
+      ExternalMessagePortProviderActions.INITIALIZE_PORT,
+      {
+        data: {
+          action: ExternalMessagePortProviderActions.INITIALIZE_PORT,
+        },
+        ports: [port],
+      },
+    );
+
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('should send out exam data when `sendOutExamData` is called', () => {
+    const examData: ExamData = getEmptyExamData();
+    let windowEventHandler: (event) => void = () => {};
+    const port = {
+      postMessage: jest.fn(),
+      onmessage: jest.fn(),
+    };
+
+    const window = {
+      addEventListener: (_, handler) => (windowEventHandler = handler),
+    };
+
+    const externalMessagePortProvider = new ExternalMessagePortProvider(
+      window as Window,
+    );
+
+    windowEventHandler.call(
+      ExternalMessagePortProviderActions.INITIALIZE_PORT,
+      {
+        data: {
+          action: ExternalMessagePortProviderActions.INITIALIZE_PORT,
+        },
+        ports: [port],
+      },
+    );
+
+    port.postMessage = jest.fn();
+
+    externalMessagePortProvider.sendOutExamData(examData);
+
+    expect(port.postMessage).toHaveBeenCalledWith(examData);
+  });
+
+  it('Updates event listeners when `SET_EXAM_DATA` event is received', () => {
+    const handler = jest.fn();
+    const examData = getEmptyExamData();
+    const port = {
+      postMessage: jest.fn(),
+      onmessage: jest.fn(),
+    };
+    let windowEventHandler: (event) => void = () => {};
+
+    const window = {
+      addEventListener: (_, handler) => (windowEventHandler = handler),
+    };
+
+    const externalMessagePortProvider = new ExternalMessagePortProvider(
+      window as Window,
+    );
+
+    externalMessagePortProvider.subscribeToOnExamData(handler);
+
+    windowEventHandler.call(
+      ExternalMessagePortProviderActions.INITIALIZE_PORT,
+      {
+        data: {
+          action: ExternalMessagePortProviderActions.INITIALIZE_PORT,
+        },
+        ports: [port],
+      },
+    );
+
+    port.onmessage({
+      data: {
+        action: ExternalMessagePortProviderActions.SET_EXAM_DATA,
+        examData,
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith(examData);
+  });
+
+  it('Throws an exception when `SET_EXAM_DATA` event is received but the event has no exam data', () => {
+    const handler = jest.fn();
+    const port = {
+      postMessage: jest.fn(),
+      onmessage: jest.fn(),
+    };
+    let windowEventHandler: (event) => void = () => {};
+
+    const window = {
+      addEventListener: (_, handler) => (windowEventHandler = handler),
+    };
+
+    const externalMessagePortProvider = new ExternalMessagePortProvider(
+      window as Window,
+    );
+
+    externalMessagePortProvider.subscribeToOnExamData(handler);
+
+    windowEventHandler.call(
+      ExternalMessagePortProviderActions.INITIALIZE_PORT,
+      {
+        data: {
+          action: ExternalMessagePortProviderActions.INITIALIZE_PORT,
+        },
+        ports: [port],
+      },
+    );
+
+    expect(() => {
+      port.onmessage({
+        data: {
+          action: ExternalMessagePortProviderActions.SET_EXAM_DATA,
+        },
+      });
+    }).toThrowError('Exam data is required.');
+  });
+});

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
@@ -27,6 +27,9 @@ const storyInitializer = (getRandomExamData) => {
     );
     const readonlyButton = document.querySelector('button[readonly]');
     const flipFlagButton = document.querySelector('button[flip-flag]');
+    const classificationStyleSelect = document.querySelector(
+      'select[classification-style]',
+    );
     const channel = new MessageChannel();
     const port1 = channel.port1;
     let readonly = false;
@@ -96,10 +99,17 @@ const storyInitializer = (getRandomExamData) => {
 
     flipFlagButton?.addEventListener('click', () => {
       readonly = !readonly;
-
       port1.postMessage({
         action: 'SET_READONLY',
         readonly,
+      });
+    });
+
+    classificationStyleSelect?.addEventListener('change', (e) => {
+      const select = e.target as HTMLSelectElement;
+      port1.postMessage({
+        action: 'SET_CLASSIFICATION_STYLE',
+        classificationStyle: select.options[select.selectedIndex].value,
       });
     });
   });
@@ -132,6 +142,14 @@ const template = () => html`
     <li><button random-incomplete-exam>Load random incomplete exam</button></li>
     <li><button readonly>Load random exam as readonly</button></li>
     <li><button flip-flag>Flip readonly flag</button></li>
+    <li>
+      <label>Classification style:</label>
+      <select classification-style>
+        <option value=""></option>
+        <option value="visible">visible</option>
+        <option value="static">static</option>
+      </select>
+    </li>
   </ul>
   <script>
     // We register this way to avoid getting exceptions of functions being already declared when navigating between stories.

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
@@ -3,22 +3,24 @@ import {ExamData} from '@core/domain';
 
 export class ExternalMessagePortProviderActions {
   public static INITIALIZE_PORT = 'INITIALIZE_PORT';
-  public static ON_EXAM_DATA = 'ON_EXAM_DATA';
-  public static ON_EXTERNAL_PORT = 'ON_EXTERNAL_PORT';
-  public static ON_READONLY = 'ON_READONLY';
   public static SET_EXAM_DATA = 'SET_EXAM_DATA';
   public static SET_READONLY = 'SET_READONLY';
+  public static SET_CLASSIFICATION_STYLE = 'SET_CLASSIFICATION_STYLE';
 }
 
 export class ExternalMessagePortProvider implements IExternalMessageProvider {
-  private handlers: Array<
-    (actionType: string, examData: ExamData | null, readonly: boolean) => void
+  private onExamDataHandlers: Array<(examData: ExamData) => void> = [];
+  private onReadonlyHandlers: Array<(readonly: boolean) => void> = [];
+  private onClassificationStyleHandlers: Array<
+    (classificationStyle: string) => void
   > = [];
+  private onExternalPortHandlers: Array<() => void> = [];
+
   private port: MessagePort | null = null;
 
-  constructor() {
+  constructor(globalWindow: Window = window) {
     // Listen for the initial port transfer message
-    window.addEventListener('message', (e) => this.initPort(e));
+    globalWindow.addEventListener('message', (e) => this.initPort(e));
   }
 
   private initPort(e: MessageEvent) {
@@ -26,14 +28,17 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
       e.data.action &&
       e.data.action === ExternalMessagePortProviderActions.INITIALIZE_PORT
     ) {
-      this.port = e.ports[0] ?? null;
-      this.port.onmessage = (e: MessageEvent) =>
-        this.onPortMessage(e.data.action, e.data.readonly, e.data.examData);
-      this.dispatch({
-        examData: null,
-        readonly: false,
-        type: ExternalMessagePortProviderActions.ON_EXTERNAL_PORT,
-      });
+      this.port = e.ports[0];
+      this.port.onmessage = (e: MessageEvent) => {
+        this.validateMessageEvent(e);
+        this.onPortMessage(
+          e.data.action,
+          e.data.readonly,
+          e.data.examData,
+          e.data.classificationStyle,
+        );
+      };
+      this.dispatchOnExternalPort();
     }
   }
 
@@ -41,25 +46,24 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     action: string,
     readonly: boolean,
     examData: ExamData | null = null,
+    classificationStyle: string = '',
   ) {
     if (action === ExternalMessagePortProviderActions.SET_EXAM_DATA) {
       if (!examData) {
         throw new Error('Exam data is required for SET_EXAM_DATA action.');
       }
 
-      this.dispatch({
-        examData,
-        type: ExternalMessagePortProviderActions.ON_EXAM_DATA,
-        readonly,
-      });
+      this.dispatchOnExamData(examData);
     }
 
     if (action === ExternalMessagePortProviderActions.SET_READONLY) {
-      this.dispatch({
-        examData: null,
-        type: ExternalMessagePortProviderActions.ON_READONLY,
-        readonly,
-      });
+      this.dispatchOnReadonly(readonly);
+    }
+
+    if (
+      action === ExternalMessagePortProviderActions.SET_CLASSIFICATION_STYLE
+    ) {
+      this.dispatchOnClassificationStyle(classificationStyle);
     }
   }
 
@@ -67,35 +71,95 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     this.port?.postMessage(examData);
   }
 
-  private dispatch(action: {
-    type: string;
-    examData: ExamData | null;
-    readonly: boolean;
-  }) {
-    this.handlers.forEach((handler) =>
-      handler(action.type, action.examData, action.readonly),
+  private dispatchOnExamData(examData: ExamData) {
+    this.onExamDataHandlers.forEach((handler) => handler(examData));
+  }
+
+  private dispatchOnReadonly(readonly: boolean) {
+    this.onReadonlyHandlers.forEach((handler) => handler(readonly));
+  }
+
+  private dispatchOnClassificationStyle(classificationStyle: string) {
+    this.onClassificationStyleHandlers.forEach((handler) =>
+      handler(classificationStyle),
     );
+  }
+
+  private dispatchOnExternalPort() {
+    this.onExternalPortHandlers.forEach((handler) => handler());
+  }
+
+  private subscribe(handler: Function, handlers: Array<Function>) {
+    handlers.push(handler);
+
+    return () => {
+      const index: number = handlers.findIndex(
+        (value: Function) => value === handler,
+      );
+      if (index > -1) {
+        handlers.splice(index, 1);
+      }
+    };
   }
 
   /*
    * returns the unsubscribe function
    */
-  public subscribe(
-    handler: (
-      action: string,
-      examData: ExamData | null,
-      readonly: boolean,
-    ) => void,
-  ) {
-    this.handlers.push(handler);
+  public subscribeToOnExamData(handler: (examData: ExamData | null) => void) {
+    return this.subscribe(handler, this.onExamDataHandlers);
+  }
 
-    return () => {
-      const index: number = this.handlers.findIndex(
-        (value: Function) => value === handler,
-      );
-      if (index > -1) {
-        this.handlers.splice(index, 1);
+  /*
+   * returns the unsubscribe function
+   */
+  public subscribeToOnReadonly(handler: (readonly: boolean) => void) {
+    return this.subscribe(handler, this.onReadonlyHandlers);
+  }
+
+  /*
+   * returns the unsubscribe function
+   */
+  public subscribeToOnClassificationStyle(
+    handler: (classificationStyle: string) => void,
+  ) {
+    return this.subscribe(handler, this.onClassificationStyleHandlers);
+  }
+
+  /*
+   * returns the unsubscribe function
+   */
+  public subscribeToOnExternalPort(handler: () => void) {
+    return this.subscribe(handler, this.onExternalPortHandlers);
+  }
+
+  private validateMessageEvent(e: MessageEvent) {
+    if (!e.data.action) {
+      throw new Error('Action is required.');
+    }
+
+    if (typeof e.data.action !== 'string') {
+      throw new Error('Action must be a string.');
+    }
+
+    if (e.data.action === ExternalMessagePortProviderActions.SET_EXAM_DATA) {
+      if (!e.data.examData) {
+        throw new Error('Exam data is required.');
       }
-    };
+    }
+
+    if (e.data.action === ExternalMessagePortProviderActions.SET_READONLY) {
+      if (typeof e.data.readonly !== 'boolean') {
+        throw new Error('Readonly must be a boolean.');
+      }
+    }
+
+    if (
+      e.data.action ===
+      ExternalMessagePortProviderActions.SET_CLASSIFICATION_STYLE
+    ) {
+      if (typeof e.data.classificationStyle !== 'string') {
+        throw new Error('Classification style must be a string.');
+      }
+    }
   }
 }

--- a/src/core/useCases/loadExternalExamData.useCase.spec.ts
+++ b/src/core/useCases/loadExternalExamData.useCase.spec.ts
@@ -22,7 +22,6 @@ describe('loadExternalExamData.useCase.ts', () => {
 
     it('sets the VAC and DAP values using the App Store Provider', async () => {
       // Arrange
-      const readonly = false;
       const vac = 'Yes';
       const dap = 'No';
       const examData = getEmptyExamData();
@@ -30,12 +29,11 @@ describe('loadExternalExamData.useCase.ts', () => {
       examData.deepAnalPressure = dap;
 
       // Act
-      await loadExternalExamDataUseCase(appStoreProvider, examData, readonly);
+      await loadExternalExamDataUseCase(appStoreProvider, examData);
 
       // Assert
       expect(appStoreProvider.setActiveCell).toHaveBeenCalledWith(null, []);
       expect(appStoreProvider.setGridModel).toHaveBeenCalled();
-      expect(appStoreProvider.setReadonly).toHaveBeenCalledWith(readonly);
       expect(appStoreProvider.setTotals).toHaveBeenCalled();
       expect(appStoreProvider.setVacDap).toHaveBeenCalledWith(vac, dap);
       expect(appStoreProvider.setExtraInputs).toHaveBeenCalled();

--- a/src/core/useCases/loadExternalExamData.useCase.ts
+++ b/src/core/useCases/loadExternalExamData.useCase.ts
@@ -9,7 +9,6 @@ import {
 export const loadExternalExamDataUseCase = async (
   appStoreProvider: IIsncsciAppStoreProvider,
   examData: ExamData,
-  readonly: boolean = false,
 ) => {
   // 1. Validate exam data
   const errors = validateExamData(examData);
@@ -27,7 +26,6 @@ export const loadExternalExamDataUseCase = async (
   // 4. Update state
   await appStoreProvider.setActiveCell(null, []);
   await appStoreProvider.setGridModel(gridModel);
-  await appStoreProvider.setReadonly(readonly);
   await appStoreProvider.setTotals(totals);
   await appStoreProvider.setVacDap(
     examData.voluntaryAnalContraction,


### PR DESCRIPTION
Closes #223 

## Problem

We need to let external applications decide what display style to use.

## Solution

We expose the classification style property so they can change it using the external port.

## Testing

You can test the different styling options in the [Storybook story](https://64f8d7c6e093108e99084a70-gjzqmtapam.chromatic.com/?path=/story/app-externalmessageportprovider--primary)