### PR TITLE
[connect] Expose the calculation function to Praxis Connect

### DIFF
--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.mdx
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.mdx
@@ -44,8 +44,11 @@ isncsciIframe.addEventListener('load', () => {
 });
 ```
 
-You can pass exam data to the ISNCSCI form by sending a message with the `action` of `SET_EXAM_DATA` and the exam data.
-You can also pass the `readonly` flag to make the form readonly.
+### Sending messages to the ISNCSCI form
+
+You can call the following actions to update a form:
+
+`SET_EXAM_DATA`: Pass exam data to the form.
 
 ```typescript
 // Create exam data
@@ -73,14 +76,29 @@ let examData = {
 };
 
 // Send the exam data through the port
-port1.postMessage({action: 'SET_EXAM_DATA', examData, readonly: false});
+port1.postMessage({action: 'SET_EXAM_DATA', examData});
 ```
 
-Making the component readonly is also possible without having to pass exam data.
-You can send a message with the `action` of `SET_READONLY` and the `readonly` flag.
+`SET_READONLY`: Make the form readonly.
 
 ```typescript
 port1.postMessage({action: 'SET_READONLY', readonly: true});
+```
+
+`SET_CLASSIFICATION_STYLE`: Sets how the classification panel is to be displayed:
+
+- `visible` makes the panel visible
+- `static` fixes the classification panel at the bottom of the form
+- `''` hides the classification panel
+
+```typescript
+port1.postMessage({action: 'SET_CLASSIFICATION_STYLE', style: 'visible'});
+```
+
+`CLASSIFY`: Triggers the classification logic
+
+```typescript
+port1.postMessage({action: 'CLASSIFY'});
 ```
 
 > Reference: [MDN: Using window.postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.spec.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.spec.ts
@@ -109,6 +109,43 @@ describe('ExternalMessagePortProvider', () => {
     expect(handler).toHaveBeenCalledWith(examData);
   });
 
+  it('triggers the classification when `CLASSIFY` is passed as action', () => {
+    const handler = jest.fn();
+    const port = {
+      postMessage: jest.fn(),
+      onmessage: jest.fn(),
+    };
+    let windowEventHandler: (event) => void = () => {};
+
+    const window = {
+      addEventListener: (_, handler) => (windowEventHandler = handler),
+    };
+
+    const externalMessagePortProvider = new ExternalMessagePortProvider(
+      window as Window,
+    );
+
+    externalMessagePortProvider.subscribeToOnClassify(handler);
+
+    windowEventHandler.call(
+      ExternalMessagePortProviderActions.INITIALIZE_PORT,
+      {
+        data: {
+          action: ExternalMessagePortProviderActions.INITIALIZE_PORT,
+        },
+        ports: [port],
+      },
+    );
+
+    port.onmessage({
+      data: {
+        action: ExternalMessagePortProviderActions.CLASSIFY,
+      },
+    });
+
+    expect(handler).toHaveBeenCalled();
+  });
+
   it('Throws an exception when `SET_EXAM_DATA` event is received but the event has no exam data', () => {
     const handler = jest.fn();
     const port = {

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.stories.ts
@@ -25,8 +25,8 @@ const storyInitializer = (getRandomExamData) => {
     const incompleteExamButton = document.querySelector(
       'button[random-incomplete-exam]',
     );
-    const readonlyButton = document.querySelector('button[readonly]');
     const flipFlagButton = document.querySelector('button[flip-flag]');
+    const classifyButton = document.querySelector('button[classify]');
     const classificationStyleSelect = document.querySelector(
       'select[classification-style]',
     );
@@ -54,10 +54,8 @@ const storyInitializer = (getRandomExamData) => {
     }
 
     randomExamButton?.addEventListener('click', () => {
-      readonly = false;
       port1.postMessage({
         action: 'SET_EXAM_DATA',
-        readonly,
         examData: getRandomExamData(),
       });
     });
@@ -83,17 +81,7 @@ const storyInitializer = (getRandomExamData) => {
 
       port1.postMessage({
         action: 'SET_EXAM_DATA',
-        readonly: false,
         examData,
-      });
-    });
-
-    readonlyButton?.addEventListener('click', () => {
-      readonly = true;
-      port1.postMessage({
-        action: 'SET_EXAM_DATA',
-        readonly,
-        examData: getRandomExamData(),
       });
     });
 
@@ -102,6 +90,12 @@ const storyInitializer = (getRandomExamData) => {
       port1.postMessage({
         action: 'SET_READONLY',
         readonly,
+      });
+    });
+
+    classifyButton?.addEventListener('click', () => {
+      port1.postMessage({
+        action: 'CLASSIFY',
       });
     });
 
@@ -140,8 +134,8 @@ const template = () => html`
   <ul controls>
     <li><button random-exam>Load random exam</button></li>
     <li><button random-incomplete-exam>Load random incomplete exam</button></li>
-    <li><button readonly>Load random exam as readonly</button></li>
     <li><button flip-flag>Flip readonly flag</button></li>
+    <li><button classify>Classify</button></li>
     <li>
       <label>Classification style:</label>
       <select classification-style>

--- a/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
+++ b/src/app/providers/externalMessagePort.provider/externalMessagePort.provider.ts
@@ -6,6 +6,7 @@ export class ExternalMessagePortProviderActions {
   public static SET_EXAM_DATA = 'SET_EXAM_DATA';
   public static SET_READONLY = 'SET_READONLY';
   public static SET_CLASSIFICATION_STYLE = 'SET_CLASSIFICATION_STYLE';
+  public static CLASSIFY = 'CLASSIFY';
 }
 
 export class ExternalMessagePortProvider implements IExternalMessageProvider {
@@ -14,6 +15,7 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
   private onClassificationStyleHandlers: Array<
     (classificationStyle: string) => void
   > = [];
+  private onClassifyHandlers: Array<() => void> = [];
   private onExternalPortHandlers: Array<() => void> = [];
 
   private port: MessagePort | null = null;
@@ -65,6 +67,10 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     ) {
       this.dispatchOnClassificationStyle(classificationStyle);
     }
+
+    if (action === ExternalMessagePortProviderActions.CLASSIFY) {
+      this.dispatchOnClassify();
+    }
   }
 
   public sendOutExamData(examData: ExamData) {
@@ -83,6 +89,10 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     this.onClassificationStyleHandlers.forEach((handler) =>
       handler(classificationStyle),
     );
+  }
+
+  private dispatchOnClassify() {
+    this.onClassifyHandlers.forEach((handler) => handler());
   }
 
   private dispatchOnExternalPort() {
@@ -123,6 +133,13 @@ export class ExternalMessagePortProvider implements IExternalMessageProvider {
     handler: (classificationStyle: string) => void,
   ) {
     return this.subscribe(handler, this.onClassificationStyleHandlers);
+  }
+
+  /*
+   * returns the unsubscribe function
+   */
+  public subscribeToOnClassify(handler: () => void) {
+    return this.subscribe(handler, this.onClassifyHandlers);
   }
 
   /*

--- a/src/app/webApp.ts
+++ b/src/app/webApp.ts
@@ -61,6 +61,7 @@ export class PraxisIsncsciWebApp extends HTMLElement {
   private unsubscribeFromReadonlyHandler: Function | null = null;
   private unsubscribeFromExamDataHandler: Function | null = null;
   private unsubscribeFromClassificationStyleHandler: Function | null = null;
+  private unsubscribeFromClassifyHandler: Function | null = null;
   private ready = false;
 
   constructor() {
@@ -107,6 +108,11 @@ export class PraxisIsncsciWebApp extends HTMLElement {
           this.externalMessagePortProvider_onClassificationStyle(
             classificationStyle,
           ),
+      );
+
+    this.unsubscribeFromClassifyHandler =
+      this.externalMessagePortProvider.subscribeToOnClassify(() =>
+        this.classify(),
       );
 
     this.appLayout = document.querySelector('praxis-isncsci-app-layout');
@@ -182,6 +188,10 @@ export class PraxisIsncsciWebApp extends HTMLElement {
     if (this.unsubscribeFromReadonlyHandler) {
       this.unsubscribeFromReadonlyHandler();
     }
+
+    if (this.unsubscribeFromClassifyHandler) {
+      this.unsubscribeFromClassifyHandler();
+    }
   }
 
   private closeClassification() {
@@ -198,6 +208,10 @@ export class PraxisIsncsciWebApp extends HTMLElement {
   }
 
   private calculate_onClick() {
+    this.classify();
+  }
+
+  private classify() {
     if (!this.appLayout || !this.classification) {
       return;
     }


### PR DESCRIPTION
Closes #229

## Problem

**Praxis Connect** wants control to trigger the classification on their end.

## Solution

I've added a `CLASSIFY` action to the **external message port provider** so that the classification process can be triggered by the importing system.

## Testing

- [x] Can trigger the classification externally

<details>
  <summary>Test case</summary>

  1. Navigate to the [external message provider **Storybook** story](https://64f8d7c6e093108e99084a70-rcpbswrfmy.chromatic.com/?path=/story/app-externalmessageportprovider--primary)
  2. Press the **Load random exam** button
  3. Confirm that the form gets populated
  4. Press the **Classify** button
  5. Confirm that the classification panel opens with the results of the calculation

</details>
