### PR TITLE
Isncsci data input loss when saving partially completed isncsci with missing VAC and DAP or VAC and DAP=UNK

### DIFF
--- a/src/core/domain/binaryObservation.ts
+++ b/src/core/domain/binaryObservation.ts
@@ -1,6 +1,7 @@
-export type BinaryObservation = 'Yes' | 'No' | 'NT';
+export type BinaryObservation = 'Yes' | 'No' | 'NT' | 'UNK';
 export const ValidBinaryObservationValues: BinaryObservation[] = [
   'Yes',
   'No',
+  'UNK',
   'NT',
 ];

--- a/src/core/helpers/examData.helper.ts
+++ b/src/core/helpers/examData.helper.ts
@@ -814,6 +814,22 @@ export const getEmptyExamData = (): ExamData => {
   };
 };
 
+export const getExamDataWithAllNormalValues = (): ExamData => {
+  const examData = getEmptyExamData();
+  examData.voluntaryAnalContraction = 'Yes';
+  examData.deepAnalPressure = 'Yes';
+
+  Object.keys(examData).forEach((key) => {
+    if (/^(right|left)(LightTouch|PinPrick)(?!.*NotDueToSci$)/.test(key)) {
+      examData[key] = '2';
+    } else if (/^(right|left)Motor(?!.*NotDueToSci$)/.test(key)) {
+      examData[key] = '5';
+    }
+  });
+
+  return examData;
+};
+
 export const cloneExamData = (
   examData: ExamData,
   convertUnkToNt: boolean = false,

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -10,6 +10,7 @@ export {
   getCellRow,
   getEmptyExamData,
   getExamDataFromGridModel,
+  getExamDataWithAllNormalValues,
   validateExamData,
 } from './examData.helper';
 

--- a/src/core/useCases/calculate.useCase.spec.ts
+++ b/src/core/useCases/calculate.useCase.spec.ts
@@ -1,0 +1,54 @@
+import {
+  IExternalMessageProvider,
+  IIsncsciAppStoreProvider,
+} from '@core/boundaries';
+import {
+  bindExamDataToGridModel,
+  getExamDataWithAllNormalValues,
+} from '@core/helpers';
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import {getAppStoreProviderMock} from '@testHelpers/appStoreProviderMocks';
+import {calculateUseCase} from './calculate.useCase';
+import {IsncsciExamProvider} from '@app/providers';
+
+describe('calculate.useCase.ts', () => {
+  let appStoreProvider: IIsncsciAppStoreProvider;
+  let externalMessageProvider: IExternalMessageProvider;
+  const examProvider = new IsncsciExamProvider();
+
+  beforeEach(() => {
+    appStoreProvider = getAppStoreProviderMock();
+    externalMessageProvider = {
+      sendOutExamData: jest.fn(),
+    };
+    jest.resetModules();
+  });
+
+  it('can calculate exam with VAC and DAP equal to `UNK`', async () => {
+    // Arrange
+    const vac = 'UNK';
+    const dap = 'UNK';
+    const gridModel = bindExamDataToGridModel(getExamDataWithAllNormalValues());
+
+    // Act
+    try {
+      await calculateUseCase(
+        gridModel,
+        vac,
+        dap,
+        null,
+        null,
+        '',
+        appStoreProvider,
+        examProvider,
+        externalMessageProvider,
+      );
+    } catch (error: any) {
+      throw new Error(`Calculation failed: ${error.message}`);
+    }
+
+    // Assert
+    expect(appStoreProvider.setTotals).toBeCalled();
+    expect(externalMessageProvider.sendOutExamData).toBeCalled();
+  });
+});


### PR DESCRIPTION
Closes #226 

## Problem

`UNK` is missing as a valid **VAC** and **DAP** value making the exams not pass validation during calculation.

## Solution

Added `UNK` to the enumerations in `binaryObservation.ts` making it a valid input. They get converted from `UNK` to `NT` during the calculation process.

## Testing

- [x] 1. Can perform a calculation when **VAC** and **DAP** are set to `UNK`

<details>
  <summary>Test case</summary>

  1. Navigate to the [dev build associated to this issue](https://brave-meadow-05543dc10-234.centralus.4.azurestaticapps.net)
  2. Enter all normal values for motor and sensory
  3. Select `UNK` for **VAC** and **DAP**
  4. Press calculate
  5. Confirm that the calculation is successful

</details>