### PR TITLE
[227] Overlapping human body image and input data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isncsci-ui",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isncsci-ui",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "isncsci": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "create-custom-elements-manifest:dist": "cem analyze --config custom-elements-manifest-dist.config.mjs"
   },
   "types": "./index.d.ts",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "readme": "README.md",
-  "_id": "isncsci-ui@1.0.4"
+  "_id": "isncsci-ui@1.0.5"
 }

--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
@@ -53,13 +53,29 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
 
       [diagram] ::slotted([slot="key-points-diagram"]) {
         left: 50%;
-        position: fixed;
+        position: relative;
         transform: translateX(-50%);
       }
 
-      @container (min-width: 48rem) {
+      @media (min-height: 76.5rem) {
+        [diagram] ::slotted([slot="key-points-diagram"]) {
+          position: fixed;
+        }
+      }
+
+      @container (min-width: 53.125rem) {
         [diagram] {
           display: block;
+        }
+
+        [diagram] ::slotted([slot="key-points-diagram"]) {
+          transform: translateX(-50%) scale(0.8);
+        }
+      }
+
+      @container (min-width: 58.125rem) {
+        [diagram] ::slotted([slot="key-points-diagram"]) {
+          transform: translateX(-50%) scale(1);
         }
       }
     </style>


### PR DESCRIPTION
Closes #227 

## Problem

In certain screen breakpoints, the key points diagram is overlapping with the grid and bottom input elements.

## Solution

- Do not use `position: fixed` on the diagram is the screen height is less than `1224px`. This way there will be no overlap with the bottom input elements
- Show the diagram, but at 80% size, when the screen is at least `850px` wide
- Set the diagram size to 100% when the screen size is at least `930px` wide 