### PR TITLE
[239] Praxis Connect ISNCSCI control - Body diagram is not centred

### DIFF
--- a/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
+++ b/src/web/praxisIsncsciInputLayout/praxisIsncsciInputLayout.ts
@@ -23,7 +23,7 @@ export class PraxisIsncsciInputLayout extends HTMLElement {
       }
 
       [grid-section] {
-        --grid-gap: var(--space-1);
+        --grid-gap: var(--space-12);
         display: flex;
         justify-content: center;
       }


### PR DESCRIPTION
Closes https://github.com/praxis-isncsci/ui/issues/239

Thank you for letting me contribute to this project.

## Problem
 Diagram is not centered

## Solution
added ``grid-gap of 3rem i.e var(--space-12)``

## Screenshot
<img width="951" alt="image" src="https://github.com/praxis-isncsci/ui/assets/36575352/5ed4cd7e-0751-4f69-808e-aeb069364755">
